### PR TITLE
Add functional vuln_check

### DIFF
--- a/Security_Scripts/vuln_check/README.md
+++ b/Security_Scripts/vuln_check/README.md
@@ -1,68 +1,62 @@
-# markdown_html_gen.py
+# vuln_check.py
 
 ## Purpose
-
-Converts structured scan or analysis data into a Markdown-formatted `.md` report file. Useful for quickly creating readable summaries from tool output like vulnerability scans or system inspections.
+Matches discovered service versions against a small, local database of CVEs. Use it to quickly identify known vulnerabilities in scan output from tools like `shodan-scanner.py`.
 
 ## Features
-
-- Accepts nested dictionaries and lists
-- Outputs clean, human-readable Markdown reports
-- Generates headers for each section and key-value bullet lists
+- Accepts JSON scan results containing service names and versions
+- Looks up each service/version pair in an easily extendable CVE dictionary
+- Outputs a list of vulnerable services with their matching CVE IDs
+- Supports saving results to a JSON file or printing to the console
 
 ## Requirements
-
 - Python 3.x
 
-## Installation
-
-No external libraries required.
+No external libraries are required beyond the Python standard library.
 
 ## Usage
-
-Run the script directly with embedded sample data:
-
 ```bash
-python3 markdown_html_gen.py
+python3 vuln_check.py -i shodan_results.json -o cve_matches.json
 ```
-To use with your own data:
 
-```python
-from markdown_html_gen import generate_markdown_report, save_report
+Arguments
+- `-i, --input` – JSON file with service scan data (required)
+- `-o, --output` – Optional JSON file to write matches
 
-my_data = {
-    "Host Info": {"IP": "10.0.0.1", "Hostname": "target.local"},
-    "Services": ["SSH", "HTTP", "HTTPS"],
-    "Issues Found": ["CVE-2023-12345", "CVE-2023-67890"]
+## Example Input
+```json
+{
+  "198.51.100.23": {
+    "data": [
+      {"port": 80, "product": "Apache httpd", "version": "2.4.41"},
+      {"port": 22, "product": "OpenSSH", "version": "7.4"}
+    ]
+  }
 }
 ```
-markdown = generate_markdown_report(my_data)
 
-save_report(markdown, "my_scan_report.md")
-
-## Example Output (Markdown)
-```markdown
-# Scan Report
-
-## Host Info
-- **IP**: 192.168.1.1
-- **Hostname**: example.local
-
-## Open Ports
-- 22
-- 80
-- 443
-
-## Vulnerabilities
-- CVE-2021-41773
-- CVE-2021-42013
+## Example Output
+```json
+[
+  {
+    "host": "198.51.100.23",
+    "port": 80,
+    "service": "Apache httpd",
+    "version": "2.4.41",
+    "cves": ["CVE-2021-41773", "CVE-2021-42013"]
+  },
+  {
+    "host": "198.51.100.23",
+    "port": 22,
+    "service": "OpenSSH",
+    "version": "7.4",
+    "cves": ["CVE-2018-15473"]
+  }
+]
 ```
-## Integration
-Use this after:
 
-- `csv_json_export.py` or `exploit_checker.py` to convert JSON findings into Markdown
-
-- Manual aggregation of findings for simple reporting
+## Security Context
+Running this script helps highlight services that may be exploitable based on known CVEs. Always use it only on networks and systems you are authorized to test.
 
 ## License
 MIT License. Use at your own risk.

--- a/Security_Scripts/vuln_check/vuln_check.py
+++ b/Security_Scripts/vuln_check/vuln_check.py
@@ -1,37 +1,89 @@
 #!/usr/bin/env python3
+"""vuln_check.py
+Match discovered services and versions to a small CVE list.
 
-def generate_markdown_report(data):
-    lines = ["# Scan Report\n"]
-    for section, contents in data.items():
-        lines.append(f"## {section}\n")
-        if isinstance(contents, dict):
-            for key, value in contents.items():
-                lines.append(f"- **{key}**: {value}")
-        elif isinstance(contents, list):
-            for item in contents:
-                lines.append(f"- {item}")
-        else:
-            lines.append(str(contents))
-        lines.append("")  # Add blank line for spacing
-    return "\n".join(lines)
-
-def save_report(markdown_str, filename="report.md"):
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(markdown_str)
-    print(f"[+] Report saved as {filename}")
-
-if __name__ == "__main__":
-    sample_data = {
-        "Host Info": {
-            "IP": "192.168.1.1",
-            "Hostname": "example.local"
-        },
-        "Open Ports": [22, 80, 443],
-        "Vulnerabilities": [
-            "CVE-2021-41773",
-            "CVE-2021-42013"
+The script expects JSON input produced by scanners such as shodan-scanner.py.
+Example format:
+{
+    "198.51.100.23": {
+        "data": [
+            {"port": 80, "product": "Apache httpd", "version": "2.4.41"},
+            {"port": 22, "product": "OpenSSH", "version": "7.4"}
         ]
     }
+}
+"""
 
-    markdown_report = generate_markdown_report(sample_data)
-    save_report(markdown_report)
+import argparse
+import json
+from typing import Dict, List
+
+# Simple built-in vulnerability database.
+# Keys are "<product> <version>" in lowercase.
+VULN_DB: Dict[str, List[str]] = {
+    "apache httpd 2.4.41": ["CVE-2021-41773", "CVE-2021-42013"],
+    "nginx 1.18.0": ["CVE-2021-23017"],
+    "openssh 7.4": ["CVE-2018-15473"],
+}
+
+
+def load_input(path: str) -> Dict:
+    """Load JSON scan results from *path*."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def match_cves(scan_data: Dict) -> List[Dict[str, str]]:
+    """Return a list of vulnerable services with CVE matches."""
+    results: List[Dict[str, str]] = []
+    for host, info in scan_data.items():
+        services = info.get("data", [])
+        for service in services:
+            product = service.get("product")
+            version = service.get("version")
+            port = service.get("port")
+            if not (product and version):
+                continue
+            key = f"{product.lower()} {version.lower()}"
+            cves = VULN_DB.get(key)
+            if cves:
+                results.append(
+                    {
+                        "host": host,
+                        "port": port,
+                        "service": product,
+                        "version": version,
+                        "cves": cves,
+                    }
+                )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Match discovered service versions against a local CVE list"
+    )
+    parser.add_argument(
+        "-i", "--input", required=True, help="JSON file with service scan data"
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Optional JSON file to save vulnerability matches",
+    )
+
+    args = parser.parse_args()
+
+    data = load_input(args.input)
+    matches = match_cves(data)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(matches, f, indent=4)
+        print(f"[+] Results saved to {args.output}")
+    else:
+        print(json.dumps(matches, indent=4))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a real `vuln_check.py` that compares service versions to a small CVE database
- replace README in `Security_Scripts/vuln_check` with usage instructions for the new script

## Testing
- `python3 -m py_compile Security_Scripts/vuln_check/vuln_check.py`

------
https://chatgpt.com/codex/tasks/task_e_68883ea532ac83228fcc16e534ed3dfe