### PR TITLE
Fix formatting of Security_Scripts requirements

### DIFF
--- a/Security_Scripts/requirements.txt
+++ b/Security_Scripts/requirements.txt
@@ -1,10 +1,9 @@
-`dnspython`
-`markdown`
-`pdfminer.six`
-`python-docx`
-`requests`
-`shodan`
-`python-whois`
-`ipwhois`
-`placeholder`
+dnspython
+markdown
+pdfminer.six
+python-docx
+requests
+shodan
+python-whois
+ipwhois
 


### PR DESCRIPTION
## Summary
- remove backticks and placeholder line from requirements
- list dependencies plainly one per line

## Testing
- `python -m compileall -q Security_Scripts` *(fails: SyntaxError in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68883ea3b3188322acf9d70760a7f56a