### PR TITLE
Populate security dashboard example data

### DIFF
--- a/security-dashboard/data/sample-security-scan.json
+++ b/security-dashboard/data/sample-security-scan.json
@@ -1,1 +1,9 @@
-
+[
+  {
+    "host": "192.168.1.100",
+    "port": 22,
+    "service": "ssh",
+    "vulnerability": "CVE-2025-0001",
+    "timestamp": "2025-07-25T17:00:00Z"
+  }
+]

--- a/security-dashboard/elasticsearch/mappings.json
+++ b/security-dashboard/elasticsearch/mappings.json
@@ -1,1 +1,11 @@
-
+{
+  "mappings": {
+    "properties": {
+      "host": { "type": "keyword" },
+      "port": { "type": "integer" },
+      "service": { "type": "keyword" },
+      "vulnerability": { "type": "keyword" },
+      "timestamp": { "type": "date" }
+    }
+  }
+}

--- a/security-dashboard/kibana/dashboards.json
+++ b/security-dashboard/kibana/dashboards.json
@@ -1,1 +1,12 @@
-
+[
+  {
+    "type": "dashboard",
+    "id": "basic-dashboard",
+    "attributes": {
+      "title": "Basic Security Dashboard",
+      "description": "Example dashboard layout",
+      "panelsJSON": "[]",
+      "timeRestore": false
+    }
+  }
+]

--- a/security-dashboard/kibana/index-pattern.json
+++ b/security-dashboard/kibana/index-pattern.json
@@ -1,1 +1,10 @@
-
+[
+  {
+    "type": "index-pattern",
+    "id": "security-scans",
+    "attributes": {
+      "title": "security-scans-*",
+      "timeFieldName": "timestamp"
+    }
+  }
+]

--- a/security-dashboard/kibana/visualizations.json
+++ b/security-dashboard/kibana/visualizations.json
@@ -1,1 +1,11 @@
-
+[
+  {
+    "type": "visualization",
+    "id": "vuln-count",
+    "attributes": {
+      "title": "Vulnerability Count",
+      "visState": "{}",
+      "uiStateJSON": "{}"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- fill Kibana export files with minimal placeholders
- add a simple Elasticsearch mapping
- provide example document for security scan data

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68883ea22cac8322a57bc4a8abbe8f48