### PR TITLE
Clean README code snippets

### DIFF
--- a/Security_Scripts/csv_json_export/README.md
+++ b/Security_Scripts/csv_json_export/README.md
@@ -21,12 +21,13 @@ Python 3.x
 No external libraries required. Standard Python installation is sufficient.
 
 ## Usage
-```bash```
+```bash
 # Export both CSV and JSON from a file
 python3 csv_json_export.py -i recon_results.json -f both -o exported_data
 
 # Export only CSV, using stdin
 cat recon_results.json | python3 csv_json_export.py -f csv
+```
 
 ## Arguments
 -i, --input – Path to a JSON input file (optional if using stdin)
@@ -52,8 +53,6 @@ cat recon_results.json | python3 csv_json_export.py -f csv
 ```
 ## Example Output (CSV)
 ```csv
-Copy
-Edit
 ip,port,service
 192.168.1.1,80,http
 192.168.1.2,443,https

--- a/Security_Scripts/email_head_read/README.md
+++ b/Security_Scripts/email_head_read/README.md
@@ -27,12 +27,11 @@ Arguments
 -i, --input – Path to the raw email file (.eml) to analyze
 ```
 ## Example Output
-sql
-Copy
-Edit
+```text
 SPF result: pass
 DKIM result: fail
 DMARC result: pass
+```
 
 ## Key Headers:
 `From: attacker@example.com

--- a/Security_Scripts/port-scanner/README.md
+++ b/Security_Scripts/port-scanner/README.md
@@ -27,8 +27,6 @@ python3 port_scanner.py -t 192.0.2.5 -p 1-1024 -o scan_results.json
 
 ## Example Output (scan_results.json)
   ```json
-  Copy
-  Edit
   {
     "host": "192.0.2.5",
     "open_ports": [


### PR DESCRIPTION
## Summary
- fix stray "Copy" and "Edit" lines in various READMEs
- tidy code blocks in csv_json_export and email_head_read docs

## Testing
- `grep -R "Copy" -n | grep README`
- `grep -R "Edit" -n | grep README`


------
https://chatgpt.com/codex/tasks/task_e_68883e9dedbc8322bd37827c67cb518a