### PR TITLE
Fix mislabeled security script READMEs

### DIFF
--- a/Security_Scripts/README.md
+++ b/Security_Scripts/README.md
@@ -28,7 +28,7 @@ Each script is designed to be modular, standalone, and easily extensible.
 | `cert_grabber.py`       | Fetches SSL/TLS certificate metadata (issuer, expiration, etc.).           |
 | `meta_extract.py`       | Extracts metadata from files (images, PDFs, Word documents).               |
 | `vuln_check.py`         | Matches open ports/services to known CVEs for vulnerability awareness.     |
-| `exploit_checker.py`    | Checks for common misconfigurations (e.g., SMBv1, RDP exposure).           |
+| `exploit_checker.py`    | Matches services and versions against known CVEs to flag exploitable paths.|
 | `email_head_tool.py`    | Analyzes email headers for SPF, DKIM, DMARC, and relay path insight.       |
 | `password_spray.py`     | Executes password spray attacks (test environments only) using Hydra.      |
 | `markdown_gen.py`       | Generates formatted Markdown and optional HTML reports from scan output.   |

--- a/Security_Scripts/csv_json_export/README.md
+++ b/Security_Scripts/csv_json_export/README.md
@@ -1,4 +1,4 @@
-# ```csv_json_export.py```
+# csv_json_export.py
 
 ## Purpose
 This script converts structured reconnaissance data (usually a list of dictionaries) into both .csv and .json formats. It’s designed to standardize output from tools in your recon pipeline for easier integration with reporting tools or external analysis.

--- a/Security_Scripts/vuln_check/README.md
+++ b/Security_Scripts/vuln_check/README.md
@@ -1,68 +1,51 @@
-# markdown_gen.py
+# vuln_check.py
 
 ## Purpose
 
-Converts structured scan or analysis data into a Markdown-formatted `.md` report file. Useful for quickly creating readable summaries from tool output like vulnerability scans or system inspections.
+Matches discovered services and versions against a lightweight CVE database to highlight potential vulnerabilities.
 
 ## Features
 
-- Accepts nested dictionaries and lists
-- Outputs clean, human-readable Markdown reports
-- Generates headers for each section and key-value bullet lists
+- Accepts service scan results in JSON format.
+- Maps each service/version pair to known CVEs.
+- Outputs a concise JSON report of vulnerable services.
+- Supports writing results to a file or printing to the console.
 
 ## Requirements
 
 - Python 3.x
 
-## Installation
-
-No external libraries required.
-
 ## Usage
 
-Run the script directly with embedded sample data:
-
 ```bash
-python3 markdown_gen.py
+python3 vuln_check.py -i shodan_results.json -o vuln_report.json
 ```
-To use with your own data:
 
-```python
-from markdown_gen import generate_markdown_report, save_report
+Arguments
 
-my_data = {
-    "Host Info": {"IP": "10.0.0.1", "Hostname": "target.local"},
-    "Services": ["SSH", "HTTP", "HTTPS"],
-    "Issues Found": ["CVE-2023-12345", "CVE-2023-67890"]
-}
+`-i, --input` – JSON file containing service scan data
+
+`-o, --output` – Optional path to save the vulnerability report
+
+## Example Output (snippet)
+
+```json
+[
+  {
+    "host": "198.51.100.23",
+    "port": 80,
+    "service": "Apache httpd",
+    "version": "2.4.41",
+    "cves": ["CVE-2021-41773", "CVE-2021-42013"]
+  }
+]
 ```
-markdown = generate_markdown_report(my_data)
 
-save_report(markdown, "my_scan_report.md")
+## Security Context
 
-## Example Output (Markdown)
-```markdown
-# Scan Report
-
-## Host Info
-- **IP**: 192.168.1.1
-- **Hostname**: example.local
-
-## Open Ports
-- 22
-- 80
-- 443
-
-## Vulnerabilities
-- CVE-2021-41773
-- CVE-2021-42013
-```
-## Integration
-Use this after:
-
-- `csv_json_export.py` or `exploit_checker.py` to convert JSON findings into Markdown
-
-- Manual aggregation of findings for simple reporting
+Use only on systems you are authorized to test. Validate findings before taking action.
 
 ## License
-MIT License. Use at your own risk.
+
+MIT License
+

--- a/Security_Scripts/who_geo/README.md
+++ b/Security_Scripts/who_geo/README.md
@@ -1,4 +1,4 @@
-## who_geo.py
+# who_geo.py
 Performs a Whois lookup and GeoIP geolocation query for a given domain or IP address. Outputs the combined result as structured JSON.
 
 ## Usage


### PR DESCRIPTION
## Summary
- Correct csv_json_export, who_geo, and vuln_check README headings and descriptions
- Update toolkit README with accurate exploit_checker summary

## Testing
- `python -m py_compile Security_Scripts/*/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6890c6dfc8588322a9faeb30c7f7c269