### PR TITLE
Add vulnerable and secure example activities with OWASP mappings

### DIFF
--- a/mobile-app/README.md
+++ b/mobile-app/README.md
@@ -11,5 +11,15 @@ SecurityAwarenessApp is a Kotlin-based Android application that supports the Iro
    ```
 4. Run on an emulator or connected device running Android 8.0 (API 26) or newer.
 
+## OWASP Mobile Top 10 Mapping
+
+| Module | Vulnerability | OWASP Category |
+| --- | --- | --- |
+| `vulns.storage.InsecurePrefsActivity` | Plain-text SharedPreferences | M2: Insecure Data Storage |
+| `vulns.auth.WeakPasswordActivity` | Weak password validation | M4: Insecure Authentication |
+| `vulns.network.InsecureHttpActivity` | Clear-text HTTP communication | M3: Insecure Communication |
+
+Each module has a parallel `Secure*Activity` class that demonstrates a mitigation.
+
 ## Legal Notice
 This software is provided "as is" without warranty of any kind. Use at your own risk and ensure compliance with local laws and regulations.

--- a/mobile-app/app/src/main/AndroidManifest.xml
+++ b/mobile-app/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:label="@string/app_name"
@@ -13,5 +15,23 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".vulns.storage.InsecurePrefsActivity"
+            android:exported="false" />
+        <activity
+            android:name=".vulns.storage.SecurePrefsActivity"
+            android:exported="false" />
+        <activity
+            android:name=".vulns.auth.WeakPasswordActivity"
+            android:exported="false" />
+        <activity
+            android:name=".vulns.auth.StrongPasswordActivity"
+            android:exported="false" />
+        <activity
+            android:name=".vulns.network.InsecureHttpActivity"
+            android:exported="false" />
+        <activity
+            android:name=".vulns.network.SecureHttpActivity"
+            android:exported="false" />
     </application>
 </manifest>

--- a/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/auth/StrongPasswordActivity.kt
+++ b/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/auth/StrongPasswordActivity.kt
@@ -1,0 +1,25 @@
+package com.irondillo.securityawareness.vulns.auth
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Demonstrates enforcing a stronger password policy.
+ */
+class StrongPasswordActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val password = "123"
+        val strong = password.length >= 8 &&
+            password.any { it.isDigit() } &&
+            password.any { it.isLowerCase() } &&
+            password.any { it.isUpperCase() }
+        if (strong) {
+            Toast.makeText(this, "Password accepted", Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(this, "Weak password", Toast.LENGTH_SHORT).show()
+        }
+    }
+}
+

--- a/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/auth/WeakPasswordActivity.kt
+++ b/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/auth/WeakPasswordActivity.kt
@@ -1,0 +1,21 @@
+package com.irondillo.securityawareness.vulns.auth
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Demonstrates a weak password policy with minimal checks.
+ */
+class WeakPasswordActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val password = "123"
+        if (password.length > 3) {
+            Toast.makeText(this, "Password accepted", Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(this, "Password too short", Toast.LENGTH_SHORT).show()
+        }
+    }
+}
+

--- a/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/network/InsecureHttpActivity.kt
+++ b/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/network/InsecureHttpActivity.kt
@@ -1,0 +1,18 @@
+package com.irondillo.securityawareness.vulns.network
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import java.net.URL
+
+/**
+ * Demonstrates an insecure clear-text HTTP call.
+ */
+class InsecureHttpActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Thread {
+            URL("http://example.com").openConnection().getInputStream().use { }
+        }.start()
+    }
+}
+

--- a/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/network/SecureHttpActivity.kt
+++ b/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/network/SecureHttpActivity.kt
@@ -1,0 +1,18 @@
+package com.irondillo.securityawareness.vulns.network
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import java.net.URL
+
+/**
+ * Demonstrates using HTTPS for secure communication.
+ */
+class SecureHttpActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Thread {
+            URL("https://example.com").openConnection().getInputStream().use { }
+        }.start()
+    }
+}
+

--- a/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/storage/InsecurePrefsActivity.kt
+++ b/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/storage/InsecurePrefsActivity.kt
@@ -1,0 +1,18 @@
+package com.irondillo.securityawareness.vulns.storage
+
+import android.content.Context
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Demonstrates storing sensitive data in plain text SharedPreferences.
+ */
+class InsecurePrefsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val prefs = getSharedPreferences("creds", Context.MODE_PRIVATE)
+        // Password is stored in plain text
+        prefs.edit().putString("password", "superSecret123").apply()
+    }
+}
+

--- a/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/storage/SecurePrefsActivity.kt
+++ b/mobile-app/app/src/main/java/com/irondillo/securityawareness/vulns/storage/SecurePrefsActivity.kt
@@ -1,0 +1,22 @@
+package com.irondillo.securityawareness.vulns.storage
+
+import android.content.Context
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import java.security.MessageDigest
+
+/**
+ * Demonstrates hashing a password before storing it.
+ */
+class SecurePrefsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val password = "superSecret123"
+        val hash = MessageDigest.getInstance("SHA-256")
+            .digest(password.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+        val prefs = getSharedPreferences("creds", Context.MODE_PRIVATE)
+        prefs.edit().putString("password_hash", hash).apply()
+    }
+}
+


### PR DESCRIPTION
## Summary
- add storage, auth, and network vulnerability demo activities with secure counterparts
- register new activities and network permission in the manifest
- map modules to OWASP Mobile Top 10 in README

## Testing
- `gradle build` *(fails: Plugin [id: 'com.android.application', version: '8.3.0', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b6aeaa108322ad04d6378e3e86e8