### PR TITLE
Add insecure Flask demo server with sample SQL injection tests

### DIFF
--- a/mobile-app/server/README.md
+++ b/mobile-app/server/README.md
@@ -1,0 +1,40 @@
+# Mobile App Server
+
+This folder contains a small Flask API with intentionally insecure endpoints for demonstration purposes.
+
+## Endpoints
+
+- `GET /insecure/search?name=<name>` – vulnerable SQL query built through string concatenation.
+- `GET /secure/search?name=<name>` – parameterized query protecting against SQL injection.
+
+## Run Locally
+
+```bash
+cd mobile-app/server
+python3 -m venv venv
+source venv/bin/activate
+pip install Flask
+python app.py
+```
+
+The server listens on `http://localhost:8000`.
+
+## Sample Requests
+
+**SQL Injection against insecure endpoint**
+```bash
+curl "http://localhost:8000/insecure/search?name=' OR '1'='1" | jq
+```
+
+**Secure endpoint rejecting injection**
+```bash
+curl "http://localhost:8000/secure/search?name=' OR '1'='1" | jq
+```
+
+## Tests
+
+Sample tests demonstrating exploitation and mitigation live under [`tests/`](tests/).
+Run them with:
+```bash
+python tests/test_search.py
+```

--- a/mobile-app/server/app.py
+++ b/mobile-app/server/app.py
@@ -1,0 +1,49 @@
+from flask import Flask, request, jsonify
+import sqlite3
+import os
+
+app = Flask(__name__)
+DB_PATH = os.path.join(os.path.dirname(__file__), 'users.db')
+
+def init_db():
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)')
+    cur.executemany('INSERT INTO users (name, email) VALUES (?, ?)', [
+        ('Alice', 'alice@example.com'),
+        ('Bob', 'bob@example.com'),
+        ('Charlie', 'charlie@example.com'),
+    ])
+    conn.commit()
+    conn.close()
+
+@app.route('/insecure/search')
+def insecure_search():
+    name = request.args.get('name', '')
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    query = f"SELECT id, name, email FROM users WHERE name = '{name}'"
+    try:
+        cur.execute(query)
+        rows = cur.fetchall()
+    except Exception:
+        rows = []
+    conn.close()
+    return jsonify({'query': query, 'results': rows})
+
+@app.route('/secure/search')
+def secure_search():
+    name = request.args.get('name', '')
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    query = 'SELECT id, name, email FROM users WHERE name = ?'
+    cur.execute(query, (name,))
+    rows = cur.fetchall()
+    conn.close()
+    return jsonify({'query': query, 'results': rows})
+
+if __name__ == '__main__':
+    init_db()
+    app.run(host='0.0.0.0', port=8000)

--- a/mobile-app/server/tests/test_search.py
+++ b/mobile-app/server/tests/test_search.py
@@ -1,0 +1,21 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import app, init_db
+
+init_db()
+client = app.test_client()
+
+# Exploitation example
+payload = "' OR '1'='1"
+resp_insecure = client.get(f"/insecure/search?name={payload}")
+print("Insecure results:", resp_insecure.get_json())
+
+# Mitigation example
+resp_secure = client.get(f"/secure/search?name={payload}")
+print("Secure results:", resp_secure.get_json())
+
+# Assertions documenting expected behavior
+assert len(resp_insecure.get_json()['results']) > 1, "Injection should list multiple users"
+assert len(resp_secure.get_json()['results']) == 0, "Secure endpoint should return no results"


### PR DESCRIPTION
## Summary
- add `mobile-app/server` with a tiny Flask API exposing intentionally insecure `/insecure/search` and hardened `/secure/search` endpoints
- document running the demo server on `localhost:8000` with sample curl requests
- provide `tests/test_search.py` illustrating SQL injection exploitation versus mitigation

## Testing
- `python mobile-app/server/tests/test_search.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install Flask` *(fails: Could not find a version that satisfies the requirement Flask)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b805e31c8322a057180379582d0b