### PR TITLE
Add user and teacher guides for vulnerability modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ This repository showcases several small projects for security automation, harden
 
 See each directory's README for detailed usage.
 
+## Documentation
+
+- [User Guide](docs/UserGuide.md)
+- [Teacher Guide](docs/TeacherGuide.md)
+
+
 ## Top Master's Degree Labs
 
 Below are ten standout labs from my cybersecurity master's program:

--- a/docs/TeacherGuide.md
+++ b/docs/TeacherGuide.md
@@ -1,0 +1,29 @@
+# Teacher Guide
+
+This guide helps instructors use the Iron Dillo portfolio to teach practical cybersecurity concepts to East Texas learners.
+
+## Lesson Plans
+
+### Security Scripts Toolkit
+1. **Introduction (10 min)** – Discuss ethical scanning and authorization.
+2. **Hands‑On (30 min)** – Run `shodan-scanner.py`, `vuln_check.py`, and `exploit_checker.py` on a controlled lab network.
+3. **Review (10 min)** – Summarize findings and map them to potential mitigations.
+
+### SecurityAwarenessApp Modules
+1. **Introduction (10 min)** – Highlight the OWASP Mobile Top 10.
+2. **Hands‑On (30 min)** – Explore `InsecurePrefsActivity`, `WeakPasswordActivity`, and `InsecureHttpActivity` and then compare with the secure versions.
+3. **Review (10 min)** – Facilitate discussion on secure coding practices and user impact.
+
+## Discussion Points
+- Why authorization and clear scope are vital before any assessment.
+- How small businesses in Lindale and Tyler can leverage these tools to improve security posture.
+- Real‑world consequences of insecure storage, weak authentication, and clear‑text communication.
+
+## Further Reading
+- [OWASP Mobile Top 10](https://owasp.org/www-project-mobile-top-10/)
+- [NIST Vulnerability Metrics](https://nvd.nist.gov/general)
+- [Shodan Documentation](https://developer.shodan.io/api)
+
+---
+
+Encourage learners to apply these lessons responsibly, reinforcing Iron Dillo’s mission of veteran‑owned cybersecurity for East Texas small businesses, individuals, and rural operations.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,0 +1,41 @@
+# User Guide
+
+Iron Dillo delivers veteran‑owned cybersecurity for East Texas small businesses, individuals, and rural operations. This guide walks through each vulnerability module in the portfolio and explains how to explore them safely.
+
+## Security Scripts Toolkit
+
+### `shodan-scanner.py`
+- **Walkthrough:** Provide a list of IP addresses, then run the script to retrieve service banners and Shodan vulnerability data.
+- **Learning Objective:** Understand how exposed services reveal attack surface information.
+
+### `vuln_check.py`
+- **Walkthrough:** Feed the script port scan results to match services against known CVEs.
+- **Learning Objective:** Learn to map discovered services to public vulnerabilities.
+
+### `exploit_checker.py`
+- **Walkthrough:** Supply service versions and review the reported potential exploits.
+- **Learning Objective:** Practice validating exploitability before pursuing remediation.
+
+### Safety Disclaimer
+Use these scripts only on systems you own or have explicit written permission to test. Unauthorized scanning is illegal and unethical.
+
+## SecurityAwarenessApp Modules
+
+### `vulns.storage.InsecurePrefsActivity`
+- **Walkthrough:** Enter sample data to see how plain‑text SharedPreferences can expose sensitive information.
+- **Learning Objective:** Recognize the risks of insecure local storage and the value of encryption.
+
+### `vulns.auth.WeakPasswordActivity`
+- **Walkthrough:** Try common weak passwords to observe how the app accepts them.
+- **Learning Objective:** Appreciate the need for strong password policies and input validation.
+
+### `vulns.network.InsecureHttpActivity`
+- **Walkthrough:** Trigger a network call and monitor traffic to witness unencrypted HTTP requests.
+- **Learning Objective:** See why HTTPS is essential for protecting data in transit.
+
+### Safety Disclaimer
+Run the mobile app in an isolated lab environment. Do not transmit real personal or business data through these modules.
+
+---
+
+By experimenting with these modules, learners gain practical insight into finding and mitigating vulnerabilities while preserving the safety and reputation of the communities we serve.


### PR DESCRIPTION
## Summary
- Add user guide covering vulnerability modules, learning objectives, and safety disclaimers
- Add teacher guide with lesson plans, discussion topics, and links for further reading
- Link documentation from main README

## Testing
- ⚠️ `pytest` (missing Flask dependency)


------
https://chatgpt.com/codex/tasks/task_e_68a4b9d872f4832287e6085aeacbc7b1