### PR TITLE
Add disclaimer gating and logging for vulnerable Flask demo

### DIFF
--- a/mobile-app/server/README.md
+++ b/mobile-app/server/README.md
@@ -1,10 +1,10 @@
 # Mobile App Server
 
-This folder contains a small Flask API with intentionally insecure endpoints for demonstration purposes.
+This folder contains a small Flask API with intentionally insecure endpoints for demonstration purposes. A disclaimer screen requires acknowledgment before the vulnerable route can be accessed.
 
 ## Endpoints
 
-- `GET /insecure/search?name=<name>` – vulnerable SQL query built through string concatenation.
+- `GET /insecure/search?name=<name>` – vulnerable SQL query built through string concatenation (disabled when `ENABLE_VULNERABLE_ENDPOINTS=false`).
 - `GET /secure/search?name=<name>` – parameterized query protecting against SQL injection.
 
 ## Run Locally
@@ -17,7 +17,9 @@ pip install Flask
 python app.py
 ```
 
-The server listens on `http://localhost:8000`.
+The server listens on `http://localhost:8000`. When started with `ENABLE_VULNERABLE_ENDPOINTS=false`, the insecure route returns a 404.
+
+Before exercising `/insecure/search`, visit `POST /ack` (or submit the form at the root path) to acknowledge the disclaimer. The application logs a warning if a client repeatedly submits suspicious SQL-injection payloads.
 
 ## Sample Requests
 

--- a/mobile-app/server/app.py
+++ b/mobile-app/server/app.py
@@ -1,9 +1,16 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, session, redirect
 import sqlite3
 import os
+import logging
+from collections import defaultdict
 
 app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", "dev")
 DB_PATH = os.path.join(os.path.dirname(__file__), 'users.db')
+
+logging.basicConfig(level=logging.INFO)
+ENABLE_VULNERABLE_ENDPOINTS = os.getenv("ENABLE_VULNERABLE_ENDPOINTS", "true").lower() == "true"
+attempt_counts = defaultdict(int)
 
 def init_db():
     if os.path.exists(DB_PATH):
@@ -19,19 +26,51 @@ def init_db():
     conn.commit()
     conn.close()
 
-@app.route('/insecure/search')
-def insecure_search():
-    name = request.args.get('name', '')
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    query = f"SELECT id, name, email FROM users WHERE name = '{name}'"
-    try:
-        cur.execute(query)
-        rows = cur.fetchall()
-    except Exception:
-        rows = []
-    conn.close()
-    return jsonify({'query': query, 'results': rows})
+def is_suspicious(value: str) -> bool:
+    patterns = ["'", '"', ';', '--', ' or ']
+    val = value.lower()
+    return any(p in val for p in patterns)
+
+@app.route('/')
+def disclaimer():
+    if session.get('ack'):
+        return "Disclaimer acknowledged."
+    return (
+        '<h1>Disclaimer</h1>'
+        '<p>This demo includes intentionally vulnerable modules. Use only on authorized systems.</p>'
+        '<form method="post" action="/ack"><button type="submit">I Understand</button></form>'
+    )
+
+@app.route('/ack', methods=['POST'])
+def acknowledge():
+    session['ack'] = True
+    return redirect('/')
+
+if ENABLE_VULNERABLE_ENDPOINTS:
+    @app.route('/insecure/search')
+    def insecure_search():
+        if not session.get('ack'):
+            return jsonify({'error': 'Disclaimer acknowledgment required'}), 403
+        name = request.args.get('name', '')
+        conn = sqlite3.connect(DB_PATH)
+        cur = conn.cursor()
+        query = f"SELECT id, name, email FROM users WHERE name = '{name}'"
+        try:
+            cur.execute(query)
+            rows = cur.fetchall()
+        except Exception:
+            rows = []
+        conn.close()
+        if is_suspicious(name):
+            ip = request.remote_addr or 'unknown'
+            attempt_counts[ip] += 1
+            if attempt_counts[ip] > 3:
+                app.logger.warning(f"Repeated exploitation attempts from {ip}")
+        return jsonify({'query': query, 'results': rows})
+else:
+    @app.route('/insecure/search')
+    def insecure_search():
+        return jsonify({'error': 'Vulnerable endpoint disabled'}), 404
 
 @app.route('/secure/search')
 def secure_search():

--- a/mobile-app/server/tests/test_search.py
+++ b/mobile-app/server/tests/test_search.py
@@ -5,17 +5,19 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from app import app, init_db
 
 init_db()
-client = app.test_client()
 
-# Exploitation example
-payload = "' OR '1'='1"
-resp_insecure = client.get(f"/insecure/search?name={payload}")
-print("Insecure results:", resp_insecure.get_json())
+with app.test_client() as client:
+    # Acknowledge disclaimer before using vulnerable modules
+    client.post('/ack')
 
-# Mitigation example
-resp_secure = client.get(f"/secure/search?name={payload}")
-print("Secure results:", resp_secure.get_json())
+    payload = "' OR '1'='1'"
+    for _ in range(4):
+        resp_insecure = client.get(f"/insecure/search?name={payload}")
+    print("Insecure results:", resp_insecure.get_json())
 
-# Assertions documenting expected behavior
-assert len(resp_insecure.get_json()['results']) > 1, "Injection should list multiple users"
-assert len(resp_secure.get_json()['results']) == 0, "Secure endpoint should return no results"
+    resp_secure = client.get(f"/secure/search?name={payload}")
+    print("Secure results:", resp_secure.get_json())
+
+    assert len(resp_insecure.get_json()['results']) > 1, "Injection should list multiple users"
+    assert len(resp_secure.get_json()['results']) == 0, "Secure endpoint should return no results"
+


### PR DESCRIPTION
## Summary
- require disclaimer acknowledgment before hitting vulnerable endpoints
- log repeated suspicious queries and allow disabling insecure route via `ENABLE_VULNERABLE_ENDPOINTS`
- adjust tests and docs for disclaimer flow

## Testing
- `python tests/test_search.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68a4b9db806c83228333851462d213c7