### PR TITLE
Add advanced penetration testing toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Based in East Texas, Iron Dillo Cybersecurity proudly supports individuals, smal
 - [Teacher Guide](docs/TeacherGuide.md)
 
 
+## Advanced Penetration Testing Toolkit
+
+- **Scope:** Automate and enhance exploit testing.
+- **Tools:** Python, Metasploit.
+- **Implementation:** Automate common attack patterns and integrate stealth and evasion techniques.
+- **Challenges:** Keeping the toolkit updated; ethical and legal considerations.
+- **Next Steps:** Add machine learning modules; design a GUI.
+- **Resources:** [Metasploit Documentation](https://docs.metasploit.com/)
+
+
 ## Upcoming Prototype
 
 ### Blockchain-Based Secure Logging System

--- a/Security_Scripts/README.md
+++ b/Security_Scripts/README.md
@@ -33,6 +33,7 @@ Each script is designed to be modular, standalone, and easily extensible.
 | `password_spray.py`     | Executes password spray attacks (test environments only) using Hydra.      |
 | `markdown_gen.py`       | Generates formatted Markdown and optional HTML reports from scan output.   |
 | `csv_json_export.py`    | Exports scan results to both `.csv` and `.json` formats.                   |
+| `pentest_toolkit.py`    | Automates Metasploit attack patterns with random delays for stealth.      |
 
 ---
 
@@ -96,6 +97,8 @@ pip install -r requirements.txt
 
 ```
 security-scripts-toolkit/
+├── advanced-pentest-toolkit/
+│   └── pentest_toolkit.py
 ├── cert_grabber.py
 ├── csv_json_export.py
 ├── dns_enum.py

--- a/Security_Scripts/advanced-pentest-toolkit/README.md
+++ b/Security_Scripts/advanced-pentest-toolkit/README.md
@@ -1,0 +1,23 @@
+# Advanced Penetration Testing Toolkit
+
+## Scope
+Automate and enhance exploit testing.
+
+## Tools
+- Python
+- Metasploit
+
+## Implementation
+- Automate common attack patterns via Metasploit's RPC interface
+- Integrate stealth and evasion techniques such as random execution delays
+
+## Challenges
+- Keeping the toolkit updated with new exploits and modules
+- Ethical and legal considerations; use only with explicit permission
+
+## Next Steps
+- Add machine learning modules
+- Design a graphical user interface
+
+## Resources
+- https://docs.metasploit.com/

--- a/Security_Scripts/advanced-pentest-toolkit/pentest_toolkit.py
+++ b/Security_Scripts/advanced-pentest-toolkit/pentest_toolkit.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Advanced Penetration Testing Toolkit
+
+Automates common attack patterns using the Metasploit RPC interface and applies
+basic stealth techniques such as random delays.
+
+Use only on systems you are authorized to test.
+"""
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import Optional
+
+try:
+    from metasploit.msfrpc import MsfRpcClient  # type: ignore
+except Exception:  # pragma: no cover - library may not be installed
+    MsfRpcClient = None  # type: ignore
+
+
+class AttackAutomator:
+    """Wrapper around Metasploit's RPC client to automate exploit runs."""
+
+    def __init__(self, password: str, server: str = "127.0.0.1", port: int = 55553, ssl: bool = True) -> None:
+        if MsfRpcClient is None:
+            raise RuntimeError("metasploit.msfrpc module not available")
+        self.client = MsfRpcClient(password, server=server, port=port, ssl=ssl)
+        self.logger = logging.getLogger(__name__)
+
+    def scan_and_exploit(self, target: str, exploit: str, payload: str) -> str:
+        """Run an exploit against a target with random delays for evasion."""
+        console = self.client.consoles.console()
+        self.logger.info("Launching %s against %s", exploit, target)
+        console.write(f"use {exploit}\n")
+        console.write(f"set RHOSTS {target}\n")
+        console.write(f"set PAYLOAD {payload}\n")
+        console.write("run\n")
+        self._random_delay()
+        result = console.read().get("data", "")
+        console.destroy()
+        return result
+
+    @staticmethod
+    def _random_delay() -> None:
+        time.sleep(random.uniform(0.5, 2.5))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    print("This module provides AttackAutomator to run Metasploit exploits via RPC.")


### PR DESCRIPTION
## Summary
- Start Advanced Penetration Testing Toolkit with Metasploit RPC automation and basic evasion techniques
- Document toolkit in Security Scripts README and repository overview
- Add .gitignore to remove compiled Python artifacts

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile Security_Scripts/advanced-pentest-toolkit/pentest_toolkit.py`
- `pytest` *(fails: Injection should list multiple users)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d5a6562c8322aa83d81f731098e4