### PR TITLE
Add custom IDS project entry with rule example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Based in East Texas, Iron Dillo Cybersecurity proudly supports individuals, smal
 - **Resources:** [JADX](https://github.com/skylot/jadx)
 
 
+## Custom Intrusion Detection System (IDS)
+
+- **Scope:** Detect threats via custom network rules.
+- **Tools:** Snort, Suricata.
+- **Implementation:** Install and configure IDS, write custom rule sets, and simulate attack scenarios.
+- **Challenges:** Tuning false positives, managing high-volume traffic.
+- **Next Steps:** Integrate with SIEM, pair with anomaly detection.
+- **Resources:** [Snort Documentation](https://www.snort.org/documents)
+
 ## Upcoming Prototype
 
 ### Blockchain-Based Secure Logging System

--- a/custom-ids/README.md
+++ b/custom-ids/README.md
@@ -1,0 +1,21 @@
+# Custom Intrusion Detection System (IDS)
+
+## Overview
+A lightweight lab for experimenting with Snort or Suricata to detect threats using custom network rules.
+
+## Prerequisites
+- Snort or Suricata installed
+- Network interface or pcap file for testing
+
+## Setup
+1. Install your preferred IDS (Snort or Suricata).
+2. Copy the rule file from `rules/local.rules` into your IDS rules directory.
+3. Start the IDS referencing the custom rule set.
+4. Generate or replay traffic to trigger alerts and verify detection.
+
+## Notes
+- Tuning false positives and handling high-volume traffic require ongoing adjustment.
+- Future enhancements include SIEM integration and pairing with anomaly detection.
+
+## Resources
+- [Snort Documentation](https://www.snort.org/documents)

--- a/custom-ids/rules/local.rules
+++ b/custom-ids/rules/local.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any 23 (msg:"TELNET connection attempt"; sid:1000001; rev:1;)


### PR DESCRIPTION
## Summary
- document custom intrusion detection system project in portfolio
- add sample Snort/Suricata rule and setup instructions

## Testing
- `pytest` *(fails: AssertionError in mobile-app/server/tests/test_search.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a4de2f5b648322ae0c7d5d2c49374e