### PR TITLE
Replace placeholders with real examples

### DIFF
--- a/Security_Scripts/README.md
+++ b/Security_Scripts/README.md
@@ -55,15 +55,15 @@ These are required by specific scripts:
 ### Shodan API Key
 Set your Shodan API key as an environment variable:
 ```bash
-export SHODAN_API_KEY=your_api_key_here
+export SHODAN_API_KEY=<your_shodan_api_key>
 ```
 
 ## Setup
 
 Clone the repository:
 ```bash
-git clone https://github.com/your-username/security-scripts-toolkit.git
-cd security-scripts-toolkit
+git clone https://github.com/artilleryjoe/Cybersecurity-Portfolio.git
+cd Cybersecurity-Portfolio/Security_Scripts
 ```
 
 Create and activate a virtual environment:

--- a/ansible-hardening/README.md
+++ b/ansible-hardening/README.md
@@ -6,7 +6,7 @@ A collection of modular Ansible playbooks and inventory files to automate securi
 
 ## Inventory
 
-- `inventory/hosts.yml` — Defines target hosts and connection variables. Supports SSH key and sudo access. Includes a sample `[servers]` group with placeholder IPs; replace with your environment.
+- `inventory/hosts.yml` — Defines target hosts and connection variables. Supports SSH key and sudo access. Includes a sample `[servers]` group with Lindale and Tyler hosts; update with your own systems.
 
 ---
 

--- a/ansible-hardening/inventory/hosts.yml
+++ b/ansible-hardening/inventory/hosts.yml
@@ -1,3 +1,4 @@
 [servers]
-192.0.2.10
-192.0.2.20
+# Example hosts; replace with your own Lindale and Tyler systems
+lindale ansible_host=192.0.2.10
+tyler   ansible_host=192.0.2.20

--- a/security-dashboard/README.md
+++ b/security-dashboard/README.md
@@ -4,17 +4,13 @@ This repository contains the foundational setup for a custom security dashboard 
 
 ## Components
 - Elasticsearch: Stores and indexes security scan documents
-
 - Kibana: Provides the visualization and dashboard interface
-
 - Index: security-scans with fields for host, port, service, vulnerability, and timestamp
 
 # Getting Started
 ## Prerequisites
 - Docker & Docker Compose installed
-
 - Basic familiarity with Elasticsearch and Kibana
-
 - curl or any HTTP client to ingest sample data
 
 ## Steps
@@ -23,6 +19,7 @@ Launch Elasticsearch and Kibana containers:
 ```bash
 docker-compose up -d
 ```
+
 ## Verify Elasticsearch and Kibana are running:
 
 Elasticsearch: http://localhost:9200
@@ -44,27 +41,17 @@ curl -X POST "localhost:9200/security-scans/_doc/" -H 'Content-Type: application
 }'
 ```
 - In Kibana, create a data view on security-scans and set timestamp as the time field.
-
 - Build visualizations and dashboards based on your scan data.
 
 ## Notes
 - Use .keyword fields for aggregation in visualizations (e.g., vulnerability.keyword).
-
 - Refresh the field list in Kibana if new fields aren’t showing.
-
 - This is a base setup; further ingestion automation and dashboards will be developed.
 
 ## Custom Security Dashboard
 
 ### Scope
-
 Real-time visualization of security events and metrics with a path toward enterprise-scale dashboards.
-=======
-
-Real-time visualization of security events and metrics with a path toward enterprise-scale dashboards.
-=======
-Real-time visualization of security events and metrics.
-
 
 ### Tools
 - Grafana
@@ -85,13 +72,9 @@ Real-time visualization of security events and metrics.
 - Automate data feeds
 - Configure alerts
 - Plan for enterprise-level scaling
-
 - Add Logstash and Beats pipelines for structured ingest
 - Enable TLS and role-based access control
 - Implement index lifecycle management and snapshots
-
-### Resources
-- [Grafana Docs](https://grafana.com/docs/)
 
 ### Professional ELK Stack Comparison
 
@@ -103,12 +86,8 @@ Real-time visualization of security events and metrics.
 | Management | Ad-hoc indices | Index lifecycle management and snapshot backups |
 | Monitoring | Manual checks | Centralized monitoring and alerting with X-Pack |
 
-This project starts with the base setup and is intended to grow toward the professional model over time.
-
-
 ### Resources
 - [Grafana Docs](https://grafana.com/docs/)
 
 ## License & Disclaimer
 This project is for educational and authorized professional use only. Do not use on unauthorized networks or systems.
-


### PR DESCRIPTION
## Summary
- replace placeholder clone and API key instructions in security scripts module
- clarify example hosts for Lindale and Tyler in Ansible inventory
- remove leftover placeholder text in security dashboard README

## Testing
- `pytest` *(fails: AssertionError in mobile-app/server/tests/test_search.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e250c9fc8322948f84c11d7a0cee