### PR TITLE
Add sample Snort rules for common services

### DIFF
--- a/custom-ids/README.md
+++ b/custom-ids/README.md
@@ -13,6 +13,16 @@ A lightweight lab for experimenting with Snort or Suricata to detect threats usi
 3. Start the IDS referencing the custom rule set.
 4. Generate or replay traffic to trigger alerts and verify detection.
 
+## Included Rules
+
+The `local.rules` file currently contains examples that generate alerts for common services and behaviors:
+
+- Telnet connection attempts
+- SSH connection attempts
+- Remote Desktop Protocol (RDP) connection attempts
+- HTTP requests for `/admin` pages
+- ICMP echo (ping) requests
+
 ## Notes
 - Tuning false positives and handling high-volume traffic require ongoing adjustment.
 - Future enhancements include SIEM integration and pairing with anomaly detection.

--- a/custom-ids/rules/local.rules
+++ b/custom-ids/rules/local.rules
@@ -1,1 +1,14 @@
+# Detect TELNET connection attempts
 alert tcp any any -> any 23 (msg:"TELNET connection attempt"; sid:1000001; rev:1;)
+
+# Detect SSH connection attempts
+alert tcp any any -> any 22 (msg:"SSH connection attempt"; sid:1000002; rev:1;)
+
+# Detect RDP connection attempts
+alert tcp any any -> any 3389 (msg:"RDP connection attempt"; sid:1000003; rev:1;)
+
+# Detect HTTP requests to admin pages
+alert tcp any any -> any 80 (msg:"HTTP admin page access"; content:"/admin"; http_uri; sid:1000004; rev:1;)
+
+# Detect ICMP echo requests
+alert icmp any any -> any any (msg:"ICMP echo request"; itype:8; sid:1000005; rev:1;)


### PR DESCRIPTION
## Summary
- expand local Snort rule set with examples for Telnet, SSH, RDP, HTTP admin access, and ICMP ping
- document included rules in the IDS lab README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab4509c3848322ac466ef22e173313