### PR TITLE
Add APK decompilation helper script

### DIFF
--- a/mobile-security-analysis/README.md
+++ b/mobile-security-analysis/README.md
@@ -16,6 +16,15 @@ Analyze APKs for misconfigurations, insecure data handling, and runtime vulnerab
 2. Write automated analysis scripts.
 3. Perform live testing on emulators or devices.
 
+## Usage
+Run the Python helper script to decompile an APK with apktool and JADX:
+
+```bash
+python analyze_apk.py path/to/app.apk --out output_dir
+```
+
+Ensure `apktool` and `jadx` are installed and on your `PATH`.
+
 ## Challenges
 - Obfuscation
 - Anti-debugging techniques

--- a/mobile-security-analysis/analyze_apk.py
+++ b/mobile-security-analysis/analyze_apk.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Mobile Security Analysis Tool
+Performs static analysis on Android APKs using apktool and JADX.
+
+Usage:
+    python analyze_apk.py path/to/app.apk [--out output_dir]
+"""
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def run_tool(command, cwd=None):
+    """Run an external command and stream its output."""
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"[!] Command failed: {' '.join(command)}")
+        if result.stderr:
+            print(result.stderr)
+    else:
+        if result.stdout:
+            print(result.stdout)
+    return result.returncode
+
+
+def decompile_apk(apk_path: str, out_dir: Path) -> int:
+    """Decompile APK with apktool."""
+    if shutil.which("apktool") is None:
+        print("[!] apktool not found. Please install it first.")
+        return 1
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return run_tool(["apktool", "d", "-f", apk_path, "-o", str(out_dir)])
+
+
+def jadx_decompile(apk_path: str, out_dir: Path) -> int:
+    """Generate Java source using JADX."""
+    if shutil.which("jadx") is None:
+        print("[!] jadx not found. Please install it first.")
+        return 1
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return run_tool(["jadx", apk_path, "-d", str(out_dir)])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Static APK analysis with apktool and JADX"
+    )
+    parser.add_argument("apk", help="Path to the target APK file")
+    parser.add_argument(
+        "--out", default="analysis_output", help="Directory to store results"
+    )
+    args = parser.parse_args()
+
+    apk_path = Path(args.apk).resolve()
+    output_dir = Path(args.out)
+
+    print("[*] Decompiling with apktool…")
+    decompile_apk(str(apk_path), output_dir / "apktool")
+
+    print("[*] Decompiling with JADX…")
+    jadx_decompile(str(apk_path), output_dir / "jadx")
+
+    print("[*] Analysis complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python script that leverages apktool and JADX for basic APK decompilation
- document usage of the helper script in the mobile security analysis README

## Testing
- `python -m py_compile mobile-security-analysis/analyze_apk.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab4885f07083228997a69bddba0c89