### PR TITLE
Fix Max-Cut Hamiltonian KaTeX error

### DIFF
--- a/Quantum Computing/QAOAMaxCut.md
+++ b/Quantum Computing/QAOAMaxCut.md
@@ -64,7 +64,7 @@ $$
 Let \(Q\) hold the quadratic coefficients from the minimization form. The QUBO lifts directly into a Pauli-Z based Hamiltonian whose ground state encodes the optimal cut:
 
 $$
-H_C = \sum_{i<j} Q_{ij} Z_i Z_j + \sum_i b_i Z_i.
+H_C = \sum_{(i,j)\in E} Q_{ij} Z_i Z_j + \sum_i b_i Z_i
 $$
 
 For the unweighted graphs used here, \(b_i = 0\) and each edge contributes a \(Z_i Z_j\) term with unit weight.

--- a/docs/Quantum Computing/QAOAMaxCut.md
+++ b/docs/Quantum Computing/QAOAMaxCut.md
@@ -106,9 +106,9 @@ draw_graph(graph, node_size=600, with_labels=True)
 
 2. Rewrite the optimization as a Hamiltonian whose ground state minimizes the cost function:
 
-   $$
-   H_C = \sum_{i j} Q_{ij} Z_i Z_j + \sum_i b_i Z_i.
-   $$
+    $$
+    H_C = \sum_{(i,j)\in E} Q_{ij} Z_i Z_j + \sum_i b_i Z_i
+    $$
 
    For unweighted Max-Cut, \(b_i = 0\) and \(Q_{ij} = 1\) for every edge.
 


### PR DESCRIPTION
## Summary
- update the QAOA Max-Cut documentation to render the cost Hamiltonian without KaTeX parse errors
- mirror the corrected equation in the published docs version of the write-up

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3314a10248322af3c3553d79a83f6