### PR TITLE
Improve DNS enumerator and feed generator

### DIFF
--- a/Security_Scripts/dns_enum/README.md
+++ b/Security_Scripts/dns_enum/README.md
@@ -8,7 +8,10 @@ A DNS enumeration tool that queries common DNS records and attempts AXFR zone tr
 
 - Queries DNS records: A, AAAA, MX, NS, TXT, CNAME, SOA.
 - Attempts DNS zone transfer (AXFR) on each nameserver.
-- Outputs results in JSON format.
+- Detects wildcard DNS behavior and reports DNSSEC material availability.
+- Optional subdomain brute forcing from a newline-delimited wordlist.
+- Configurable resolver timeout, custom nameservers, and rate limiting to avoid noisy scans.
+- Outputs structured JSON to disk and optionally echoes it to stdout for piping.
 
 ## Requirements
 
@@ -21,12 +24,30 @@ Install the required Python package:
   ```pip install dnspython```
 
 ## Usage
-python3 dns_enum.py -d example.com -o dns_results.json
+
+```bash
+python3 dns_enum.py \
+  --domain example.com \
+  --output dns_results.json \
+  --subdomains wordlist.txt \
+  --nameserver 1.1.1.1 --nameserver 8.8.8.8 \
+  --timeout 5 --rate-limit 0.25 --print
+```
 
 ## Arguments:
 -d, --domain: Target domain to enumerate (required).
 
 -o, --output: Output JSON file path (default: dns_enum_results.json).
+
+--subdomains: Optional newline-delimited wordlist used for passive brute forcing.
+
+--nameserver: Override the resolver's nameserver list. Repeatable.
+
+--timeout: DNS resolver timeout (seconds).
+
+--rate-limit: Seconds to sleep between individual queries to reduce traffic bursts.
+
+--print: Also echo the JSON output to stdout.
 
 ## Example Output (dns_results.json)
 ```json

--- a/Security_Scripts/dns_enum/dns_enum.py
+++ b/Security_Scripts/dns_enum/dns_enum.py
@@ -1,143 +1,215 @@
 #!/usr/bin/env python3
-"""
-dns_enum.py
-Enumerates DNS records and attempts AXFR zone transfers for a target domain.
-"""
+"""DNS enumeration helper with structured output and safety features."""
+from __future__ import annotations
 
 import argparse
 import json
 import secrets
+import sys
+import time
+from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Iterable, Sequence
 
+import dns.exception
 import dns.query
 import dns.resolver
 import dns.zone
 
-def query_dns_records(domain, resolver: dns.resolver.Resolver | None = None):
-    """Query common DNS record types for the domain."""
-    record_types = ['A', 'AAAA', 'MX', 'NS', 'TXT', 'CNAME', 'SOA']
-    results = {}
 
-    resolver = resolver or dns.resolver.Resolver()
-    for rtype in record_types:
-        try:
-            answers = resolver.resolve(domain, rtype)
-            results[rtype] = [rdata.to_text() for rdata in answers]
-        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.exception.Timeout):
-            results[rtype] = []
-    return results
+RECORD_TYPES = ("A", "AAAA", "MX", "NS", "TXT", "CNAME", "SOA")
 
-def attempt_axfr(domain):
-    """Attempt a DNS zone transfer (AXFR) for the domain."""
-    axfr_results = {}
-    resolver = dns.resolver.Resolver()
 
-    try:
-        ns_records = resolver.resolve(domain, 'NS')
-    except Exception as e:
-        print(f"[-] Failed to get NS records: {e}")
+@dataclass
+class EnumerationResult:
+    """Serializable container for enumeration results."""
+
+    domain: str
+    dns_records: dict[str, list[str]]
+    axfr_zone_transfers: dict[str, list[str] | str]
+    dnssec: dict[str, bool]
+    wildcard: bool
+    subdomains: dict[str, dict[str, list[str]]]
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class DnsEnumerator:
+    """Stateful helper that shares resolver configuration across lookups."""
+
+    def __init__(
+        self,
+        domain: str,
+        resolver: dns.resolver.Resolver | None = None,
+        *,
+        rate_limit: float = 0.0,
+    ) -> None:
+        self.domain = domain
+        self.resolver = resolver or dns.resolver.Resolver()
+        self.rate_limit = max(rate_limit, 0.0)
+
+    def query_dns_records(self, record_types: Iterable[str] = RECORD_TYPES) -> dict[str, list[str]]:
+        """Return common DNS records for the configured domain."""
+
+        results: dict[str, list[str]] = {}
+        for record_type in record_types:
+            results[record_type] = self._resolve_rdataset(self.domain, record_type)
+        return results
+
+    def attempt_zone_transfers(self, nameservers: Sequence[str]) -> dict[str, list[str] | str]:
+        """Attempt AXFR transfers against discovered or configured nameservers."""
+
+        axfr_results: dict[str, list[str] | str] = {}
+        servers = [ns.strip() for ns in nameservers if ns.strip()]
+        if not servers:
+            servers = list(self.resolver.nameservers)
+        for ns in servers:
+            try:
+                transfer = dns.query.xfr(ns, self.domain, timeout=self.resolver.timeout)
+                zone = dns.zone.from_xfr(transfer)
+            except Exception as exc:  # pragma: no cover - best effort network action
+                axfr_results[ns] = f"Zone transfer failed: {exc}"
+                continue
+            if not zone:
+                axfr_results[ns] = "Zone transfer returned no data"
+                continue
+            entries: list[str] = []
+            for name, node in zone.nodes.items():
+                for rdataset in node.rdatasets:
+                    for rdata in rdataset:
+                        entries.append(
+                            f"{name} {rdataset.ttl} {dns.rdatatype.to_text(rdataset.rdtype)} {rdata.to_text()}"
+                        )
+            axfr_results[ns] = entries
         return axfr_results
 
-    for ns in ns_records:
-        ns = ns.to_text()
+    def detect_wildcard(self) -> bool:
+        """Probe whether the domain resolves arbitrary hostnames."""
+
+        probe = f"{secrets.token_hex(8)}.{self.domain}"
+        return bool(self._resolve_rdataset(probe, "A"))
+
+    def check_dnssec(self) -> dict[str, bool]:
+        """Report DNSSEC material availability."""
+
+        dnskey_records = self._resolve_rdataset(self.domain, "DNSKEY")
+        ds_records = self._resolve_rdataset(self.domain, "DS")
+        return {
+            "dnskey": bool(dnskey_records),
+            "ds": bool(ds_records),
+            "dnssec_enabled": bool(dnskey_records and ds_records),
+        }
+
+    def brute_force_subdomains(self, wordlist: Path) -> dict[str, dict[str, list[str]]]:
+        """Resolve hostnames from a wordlist and return any records."""
+
+        findings: dict[str, dict[str, list[str]]] = {}
+        if not wordlist.exists():
+            return findings
         try:
-            zone = dns.zone.from_xfr(dns.query.xfr(ns, domain, timeout=5))
-            if zone:
-                axfr_results[ns] = []
-                for name, node in zone.nodes.items():
-                    rdatasets = node.rdatasets
-                    for rdataset in rdatasets:
-                        for rdata in rdataset:
-                            axfr_results[ns].append(f"{name} {rdataset.ttl} {rdataset.rdtype} {rdata.to_text()}")
-        except Exception as e:
-            axfr_results[ns] = f"Zone transfer failed: {e}"
-    return axfr_results
+            words = [
+                line.strip()
+                for line in wordlist.read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.startswith("#")
+            ]
+        except OSError as exc:
+            print(f"[-] Failed to read {wordlist}: {exc}", file=sys.stderr)
+            return findings
 
-
-def detect_wildcard(domain: str, resolver: dns.resolver.Resolver) -> bool:
-    probe = f"{secrets.token_hex(8)}.{domain}"
-    try:
-        resolver.resolve(probe, 'A')
-        return True
-    except Exception:
-        return False
-
-
-def check_dnssec(domain: str, resolver: dns.resolver.Resolver) -> dict:
-    status = {"dnskey": False, "ds": False}
-    try:
-        answers = resolver.resolve(domain, 'DNSKEY')
-        status["dnskey"] = len(answers) > 0
-    except Exception:
-        pass
-    try:
-        answers = resolver.resolve(domain, 'DS')
-        status["ds"] = len(answers) > 0
-    except Exception:
-        pass
-    status["dnssec_enabled"] = status["dnskey"] and status["ds"]
-    return status
-
-
-def brute_force_subdomains(domain: str, wordlist: Path, resolver: dns.resolver.Resolver) -> dict:
-    findings: dict[str, dict[str, list[str]]] = {}
-    if not wordlist.exists():
+        for word in words:
+            hostname = f"{word}.{self.domain}"
+            host_records: dict[str, list[str]] = {}
+            for record in ("A", "AAAA"):
+                answers = self._resolve_rdataset(hostname, record)
+                if answers:
+                    host_records[record] = answers
+            if host_records:
+                findings[hostname] = host_records
         return findings
-    for word in wordlist.read_text(encoding='utf-8').splitlines():
-        word = word.strip()
-        if not word:
-            continue
-        hostname = f"{word}.{domain}"
-        findings[hostname] = {}
-        for record in ('A', 'AAAA'):
-            try:
-                answers = resolver.resolve(hostname, record)
-                findings[hostname][record] = [rdata.to_text() for rdata in answers]
-            except Exception:
-                findings[hostname][record] = []
-        if not any(findings[hostname].values()):
-            findings.pop(hostname, None)
-    return findings
 
-def main():
-    parser = argparse.ArgumentParser(description="DNS Enumerator and AXFR zone transfer tool")
+    def enumerate(self, wordlist: Path | None = None) -> EnumerationResult:
+        records = self.query_dns_records()
+        dnssec = self.check_dnssec()
+        wildcard = self.detect_wildcard()
+        bruteforce = self.brute_force_subdomains(wordlist) if wordlist else {}
+        axfr = self.attempt_zone_transfers(records.get("NS", []))
+        return EnumerationResult(
+            domain=self.domain,
+            dns_records=records,
+            axfr_zone_transfers=axfr,
+            dnssec=dnssec,
+            wildcard=wildcard,
+            subdomains=bruteforce,
+        )
+
+    def _resolve_rdataset(self, name: str, record_type: str) -> list[str]:
+        """Resolve a record type while honoring the rate limit."""
+
+        if self.rate_limit:
+            time.sleep(self.rate_limit)
+        try:
+            answers = self.resolver.resolve(name, record_type)
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoNameservers):
+            return []
+        except dns.exception.DNSException as exc:
+            print(f"[-] DNS error for {name} {record_type}: {exc}", file=sys.stderr)
+            return []
+        return [rdata.to_text() for rdata in answers]
+
+
+def configure_resolver(nameservers: Sequence[str], timeout: float) -> dns.resolver.Resolver:
+    resolver = dns.resolver.Resolver()
+    cleaned = [ns.strip() for ns in nameservers if ns.strip()]
+    if cleaned:
+        resolver.nameservers = cleaned
+    resolver.timeout = timeout
+    resolver.lifetime = timeout
+    return resolver
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="DNS Enumerator with optional brute force and DNSSEC checks")
     parser.add_argument("-d", "--domain", required=True, help="Target domain to enumerate")
-    parser.add_argument("-o", "--output", default="dns_enum_results.json", help="Output JSON file")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("dns_enum_results.json"),
+        help="Output JSON file",
+    )
     parser.add_argument(
         "--subdomains",
         type=Path,
         help="Optional newline-delimited wordlist for passive subdomain brute forcing",
     )
+    parser.add_argument(
+        "--nameserver",
+        action="append",
+        default=[],
+        metavar="IP",
+        help="Override resolver nameserver (repeatable)",
+    )
+    parser.add_argument("--timeout", type=float, default=3.0, help="DNS resolver timeout in seconds (default: 3.0)")
+    parser.add_argument("--rate-limit", type=float, default=0.0, help="Seconds to sleep between DNS queries")
+    parser.add_argument("--print", dest="print_stdout", action="store_true", help="Also print the JSON report to stdout")
+    return parser.parse_args()
 
-    args = parser.parse_args()
-    domain = args.domain
 
-    resolver = dns.resolver.Resolver()
-
-    print(f"[+] Querying DNS records for {domain}...")
-    dns_records = query_dns_records(domain, resolver)
-
-    print(f"[+] Attempting AXFR zone transfer for {domain}...")
-    axfr_results = attempt_axfr(domain)
-
-    dnssec = check_dnssec(domain, resolver)
-    wildcard = detect_wildcard(domain, resolver)
-    bruteforce = brute_force_subdomains(domain, args.subdomains, resolver) if args.subdomains else {}
-
-    output = {
-        "domain": domain,
-        "dns_records": dns_records,
-        "axfr_zone_transfers": axfr_results,
-        "dnssec": dnssec,
-        "wildcard": wildcard,
-        "subdomains": bruteforce,
-    }
-
-    with open(args.output, "w") as f:
-        json.dump(output, f, indent=2)
-
+def main() -> None:
+    args = parse_args()
+    timeout = max(args.timeout, 0.5)
+    resolver = configure_resolver(args.nameserver, timeout)
+    enumerator = DnsEnumerator(args.domain, resolver=resolver, rate_limit=max(args.rate_limit, 0.0))
+    wordlist = args.subdomains if args.subdomains else None
+    result = enumerator.enumerate(wordlist)
+    payload = result.to_dict()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     print(f"[+] Enumeration complete. Results saved to {args.output}")
+    if args.print_stdout:
+        print(json.dumps(payload, indent=2))
+
 
 if __name__ == "__main__":
     main()
-

--- a/security-dashboard/README.md
+++ b/security-dashboard/README.md
@@ -104,11 +104,14 @@ Real-time visualization of security events and metrics with a path toward enterp
 Use the included Python helper to generate normalized events that Filebeat can forward to Logstash.
 
 ```bash
-python3 scripts/automate_feeds.py --batch 25 --interval 3 \\
+python3 scripts/automate_feeds.py \\
+  --batch 25 --interval 3 --max-cycles 5 \\
+  --stdout --seed 42 \\
   --logstash-endpoint https://localhost:9601
 ```
 
-- The script appends newline-delimited JSON to `data/feeds/security-events.log`.
+- The script appends newline-delimited JSON to `data/feeds/security-events.log` and can mirror events to stdout with `--stdout`.
+- Use `--max-cycles` for deterministic CI runs and `--seed` to reproduce specific datasets.
 - Filebeat (configured in `beats/filebeat.yml`) tails the file and sends events over TLS to Logstash.
 - If the optional `--logstash-endpoint` is set, events are also pushed to the HTTPS Logstash input for SOAR integrations.
 

--- a/security-dashboard/scripts/automate_feeds.py
+++ b/security-dashboard/scripts/automate_feeds.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-"""Generate continuous security events for Filebeat ingestion."""
+"""Generate normalized JSON events for the security dashboard."""
 from __future__ import annotations
 
 import argparse
 import json
 import random
+import sys
 import time
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Dict
-from urllib import request, error
+from typing import Iterable, List
+from urllib import error, request
 
 HOSTS = [
     "10.0.5.21",
@@ -17,6 +19,7 @@ HOSTS = [
     "172.16.10.9",
     "192.168.122.15",
 ]
+PORTS = [22, 80, 443, 3389, 6443]
 SERVICES = ["ssh", "rdp", "http", "kubernetes", "vpn"]
 VULNS = [
     "CVE-2024-3094",
@@ -27,38 +30,49 @@ VULNS = [
 SEVERITIES = ["low", "medium", "high", "critical"]
 
 
-def build_event() -> Dict[str, str]:
+@dataclass
+class FeedEvent:
+    host: str
+    port: int
+    service: str
+    datasource: str
+    vulnerability: str
+    severity: str
+    timestamp: str
+    tags: List[str]
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self))
+
+
+def build_event(rng: random.Random) -> FeedEvent:
     now = datetime.now(timezone.utc).isoformat()
-    host = random.choice(HOSTS)
-    service = random.choice(SERVICES)
-    severity = random.choice(SEVERITIES)
-    event = {
-        "host": host,
-        "port": random.choice([22, 80, 443, 3389, 6443]),
-        "service": service,
-        "datasource": "automated-feed",
-        "vulnerability": random.choice(VULNS),
-        "severity": severity,
-        "timestamp": now,
-        "tags": ["automated", service, severity],
-    }
-    return event
+    service = rng.choice(SERVICES)
+    severity = rng.choice(SEVERITIES)
+    return FeedEvent(
+        host=rng.choice(HOSTS),
+        port=rng.choice(PORTS),
+        service=service,
+        datasource="automated-feed",
+        vulnerability=rng.choice(VULNS),
+        severity=severity,
+        timestamp=now,
+        tags=["automated", service, severity],
+    )
 
 
-def write_events(path: Path, batch: int) -> List[Dict[str, str]]:
+def write_events(path: Path, events: Iterable[FeedEvent]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    events = [build_event() for _ in range(batch)]
     with path.open("a", encoding="utf-8") as handle:
         for event in events:
-            handle.write(json.dumps(event) + "\n")
-    return events
+            handle.write(event.to_json() + "\n")
 
 
-def push_http(events: List[Dict[str, str]], endpoint: str) -> None:
-    payload = "\n".join(json.dumps(event) for event in events).encode("utf-8")
+def push_http(events: Iterable[FeedEvent], endpoint: str, timeout: float) -> None:
+    payload = "\n".join(event.to_json() for event in events).encode("utf-8")
     req = request.Request(endpoint, data=payload, headers={"Content-Type": "application/x-ndjson"})
     try:
-        with request.urlopen(req, timeout=5) as resp:
+        with request.urlopen(req, timeout=timeout) as resp:
             resp.read()
     except error.URLError as exc:
         print(f"[warn] Failed to push events to {endpoint}: {exc}")
@@ -78,18 +92,38 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="Optional https endpoint (https://host:9601) for posting NDJSON events directly",
     )
+    parser.add_argument("--max-cycles", type=int, default=0, help="Number of batches to produce before exiting (0=infinite)")
+    parser.add_argument("--seed", type=int, help="Optional RNG seed for deterministic runs")
+    parser.add_argument("--stdout", action="store_true", help="Also print NDJSON events to stdout")
+    parser.add_argument("--http-timeout", type=float, default=5.0, help="HTTP push timeout in seconds")
     return parser.parse_args()
+
+
+def run_cycles(args: argparse.Namespace) -> None:
+    rng = random.Random(args.seed)
+    destination = Path(args.output)
+    cycle = 0
+    while True:
+        events = [build_event(rng) for _ in range(args.batch)]
+        write_events(destination, events)
+        print(f"[feed] wrote {len(events)} events to {destination}")
+        if args.stdout:
+            for event in events:
+                print(event.to_json())
+        if args.logstash_endpoint:
+            push_http(events, args.logstash_endpoint, args.http_timeout)
+        cycle += 1
+        if args.max_cycles and cycle >= args.max_cycles:
+            break
+        time.sleep(max(args.interval, 0.1))
 
 
 def main() -> None:
     args = parse_args()
-    destination = Path(args.output)
-    while True:
-        events = write_events(destination, args.batch)
-        print(f"wrote {len(events)} events to {destination}")
-        if args.logstash_endpoint:
-            push_http(events, args.logstash_endpoint)
-        time.sleep(args.interval)
+    try:
+        run_cycles(args)
+    except KeyboardInterrupt:
+        print("[feed] interrupted by user", file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refactor `dns_enum` into a reusable `DnsEnumerator` helper with DNSSEC/wildcard reporting, optional brute forcing, and safer CLI controls
- refresh the DNS enumerator README to document the new flags and usage patterns
- enhance `automate_feeds.py` so it emits structured events deterministically, adds new CLI flags, and update the dashboard README accordingly

## Testing
- `python -m py_compile Security_Scripts/dns_enum/dns_enum.py`
- `python security-dashboard/scripts/automate_feeds.py --help`
- `python security-dashboard/scripts/automate_feeds.py --batch 1 --interval 0.1 --max-cycles 1 --stdout --output /tmp/feed.log --seed 1`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193725303083228a312a002e39a650)