### PR TITLE
qrng_steganography: simplify LSB stego scripts, add keyed mode and sample cover generator

### DIFF
--- a/Security_Scripts/qrng_steganography/.gitignore
+++ b/Security_Scripts/qrng_steganography/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+recovered.txt
+stego.png
+diff.png

--- a/Security_Scripts/qrng_steganography/README.md
+++ b/Security_Scripts/qrng_steganography/README.md
@@ -1,89 +1,82 @@
-# QRNG Steganography
+# QRNG Steganography (LSB Demo)
 
-Low-level scripts demonstrating least-significant-bit (LSB) steganography using a quantum random number generator (QRNG) image as the cover. The high entropy of QRNG noise makes it an ideal carrier for hidden messages.
+This folder demonstrates simple least-significant-bit (LSB) steganography.
+
+> **Carrier note:** in this repo, `qrng.png` is an **actual QRNG-derived image** (vacuum fluctuations from ANU's QRNG project), i.e., true random entropy.
+
+## Files
+
+- `embed.py` / `extract.py`: basic sequential LSB hide/recover.
+- `embed_keyed.py` / `extract_keyed.py`: same logic, but bit positions are shuffled with a deterministic passphrase-derived seed:
+  - `hashlib.sha256(passphrase.encode()).digest()`
+- `generate_sample_cover.py`: optional synthetic 512x512 high-entropy cover generator for local testing when a real QRNG image is unavailable.
+- `requirements.txt`: Python dependencies.
 
 ## Setup
 
-### 1. Create and activate a virtual environment
-
-**Bash**
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-**PowerShell**
-```powershell
-python -m venv .venv
-. .\.venv\Scripts\Activate.ps1
-pip install -r requirements.txt
-```
+## Inputs
 
-### 2. Place a QRNG image
-Save your quantum-noise PNG in this directory as `qrng.png`.
+- Expected cover image path: `qrng.png`
+- Secret file path: `secret.txt`
 
-Quick sanity check:
+If you already have the tracked real QRNG `qrng.png`, use it directly.
+If needed for local experiments only, you can generate a synthetic replacement:
+
 ```bash
-python - <<'PY'
-from PIL import Image
-im = Image.open('qrng.png')
-print(im.mode, im.size)
-PY
+python generate_sample_cover.py
 ```
 
-### 3. Create a secret to hide
+Create secret:
+
 ```bash
-echo "Steganography test — $(date)" > secret.txt
-wc -c secret.txt
+echo "Steganography test" > secret.txt
 ```
-Keep the secret below the image capacity:
-- Grayscale: `(width*height)/8` bytes
-- RGB: `(width*height*3)/8` bytes
 
-## Usage
+## Basic mode
 
-### Embed
+Embed:
+
 ```bash
 python embed.py
 ```
-Produces `stego.png` with the secret embedded.
 
-### Extract
+Extract:
+
 ```bash
 python extract.py
 ```
-Writes the recovered data to `recovered.txt`.
 
-### Keyed Embed/Extract
+Verify:
+
 ```bash
-python embed_keyed.py    # prompts for passphrase
-python extract_keyed.py  # use same passphrase
+cmp -s secret.txt recovered.txt && echo "Match" || echo "Mismatch"
 ```
-A passphrase-derived permutation randomizes which pixels carry data.
 
-### Verify Secret Recovery
-**Linux/macOS**
+## Keyed mode
+
+Embed (prompts for passphrase):
+
 ```bash
-cmp -s secret.txt recovered.txt && echo "Match ✅" || echo "Mismatch ❌"
+python embed_keyed.py
 ```
 
-**Windows PowerShell**
-```powershell
-if (Compare-Object (Get-Content secret.txt) (Get-Content recovered.txt)) { "Mismatch ❌" } else { "Match ✅" }
-```
+Extract (same passphrase required):
 
-### Optional Diff Visualization
 ```bash
-python - <<'PY'
-from PIL import Image, ImageChops
-a = Image.open('qrng.png').convert('RGB')
-b = Image.open('stego.png').convert('RGB')
-ImageChops.difference(a,b).save('diff.png')
-print('Wrote diff.png')
-PY
+python extract_keyed.py
 ```
-`diff.png` should appear as uniform speckle; visible patterns indicate an issue.
 
-## Sample Assets
-Sample `qrng.png`, `stego.png`, `diff.png`, and `secret.txt` are included. PNG files are tracked with Git LFS to keep the repository lightweight.
+## Data format
+
+Both modes write:
+
+1. First 4 bytes = big-endian secret length.
+2. Remaining bytes = secret payload.
+
+Bits are stored in the LSB of RGB channels.

--- a/Security_Scripts/qrng_steganography/embed.py
+++ b/Security_Scripts/qrng_steganography/embed.py
@@ -1,56 +1,38 @@
 #!/usr/bin/env python3
 
-"""Embed secrets inside qrng.png using modernized CLI controls."""
-
-import argparse
-import secrets
-
-import numpy as np
 from PIL import Image
-import zlib
 
 
-MAGIC = b"IDST"
-
-
-def build_payload(secret: bytes) -> bytes:
-    return MAGIC + len(secret).to_bytes(4, "big") + zlib.crc32(secret).to_bytes(4, "big") + secret
-
-
-def embed(cover: str, secret_path: str, output: str, *, shuffle: bool = False, seed: int | None = None) -> None:
-    img = Image.open(cover).convert("RGB")
-    arr = np.array(img)
-    secret = open(secret_path, "rb").read()
-    payload = build_payload(secret)
-
-    H, W, C = arr.shape
-    capacity_bits = H * W * C
-    required_bits = len(payload) * 8
-    if required_bits > capacity_bits:
-        raise SystemExit(f"Secret too large: need {required_bits//8} bytes <= {capacity_bits//8} bytes")
-
-    flat = arr.reshape(-1)
-    bits = np.unpackbits(np.frombuffer(payload, dtype=np.uint8))
-    if shuffle:
-        rng = np.random.default_rng(seed if seed is not None else secrets.randbits(64))
-        indices = rng.choice(flat.size, size=bits.size, replace=False)
-    else:
-        indices = np.arange(bits.size)
-    flat[indices] = (flat[indices] & 0xFE) | bits
-    Image.fromarray(flat.reshape(arr.shape), "RGB").save(output, optimize=True)
-    print(f"[+] Wrote {output} with {len(payload)} bytes embedded")
+def bytes_to_bits(data: bytes) -> list[int]:
+    bits: list[int] = []
+    for b in data:
+        for i in range(7, -1, -1):
+            bits.append((b >> i) & 1)
+    return bits
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Embed secret data using LSB steganography")
-    parser.add_argument("--cover", default="qrng.png", help="Cover image path")
-    parser.add_argument("--secret", default="secret.txt", help="Secret file to embed")
-    parser.add_argument("--output", default="stego.png", help="Output stego image path")
-    parser.add_argument("--shuffle", action="store_true", help="Shuffle bit positions for added stealth")
-    parser.add_argument("--seed", type=int, help="Optional RNG seed for reproducibility")
-    args = parser.parse_args()
+    img = Image.open("qrng.png").convert("RGB")
+    pixels = list(img.getdata())
 
-    embed(args.cover, args.secret, args.output, shuffle=args.shuffle, seed=args.seed)
+    with open("secret.txt", "rb") as f:
+        secret = f.read()
+
+    payload = len(secret).to_bytes(4, "big") + secret
+    bits = bytes_to_bits(payload)
+
+    flat_channels = [c for px in pixels for c in px]
+    if len(bits) > len(flat_channels):
+        raise SystemExit("Secret is too large for this image.")
+
+    for i, bit in enumerate(bits):
+        flat_channels[i] = (flat_channels[i] & 0xFE) | bit
+
+    out_pixels = [tuple(flat_channels[i:i+3]) for i in range(0, len(flat_channels), 3)]
+    out = Image.new("RGB", img.size)
+    out.putdata(out_pixels)
+    out.save("stego.png")
+    print("Wrote stego.png")
 
 
 if __name__ == "__main__":

--- a/Security_Scripts/qrng_steganography/embed_keyed.py
+++ b/Security_Scripts/qrng_steganography/embed_keyed.py
@@ -1,59 +1,52 @@
 #!/usr/bin/env python3
 
-import argparse
 import getpass
 import hashlib
+import random
 
-import numpy as np
 from PIL import Image
-import zlib
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-
-MAGIC = b"IDKT"
 
 
-def derive_key(passphrase: bytes, cover_path: str, info: bytes) -> bytes:
-    cover_bytes = open(cover_path, "rb").read()
-    salt = hashlib.sha256(cover_bytes).digest()
-    hkdf = HKDF(algorithm=hashes.SHA256(), length=32, salt=salt, info=info, backend=default_backend())
-    return hkdf.derive(passphrase)
+def bytes_to_bits(data: bytes) -> list[int]:
+    bits: list[int] = []
+    for b in data:
+        for i in range(7, -1, -1):
+            bits.append((b >> i) & 1)
+    return bits
 
 
-def embed_keyed(cover: str, secret_path: str, out: str, *, info: bytes, passphrase: bytes) -> None:
-    key = derive_key(passphrase, cover, info)
-    img = Image.open(cover).convert("RGB")
-    arr = np.array(img)
-    H, W, C = arr.shape
-    N = H * W * C
-    secret = open(secret_path, "rb").read()
-    payload = MAGIC + len(secret).to_bytes(4, "big") + zlib.crc32(secret).to_bytes(4, "big") + secret
-    need_bits = len(payload) * 8
-    if need_bits > N:
-        raise SystemExit(f"Payload too large: need {need_bits//8} bytes <= {N//8}")
-    rng = np.random.default_rng(np.frombuffer(key, dtype=np.uint64))
-    perm = np.arange(N, dtype=np.int64)
-    rng.shuffle(perm)
-    bits = np.unpackbits(np.frombuffer(payload, dtype=np.uint8)).astype(np.uint8)
-    flat = arr.reshape(-1)
-    sel = perm[: bits.size]
-    flat[sel] = (flat[sel] & 0xFE) | bits
-    Image.fromarray(flat.reshape(arr.shape), "RGB").save(out, optimize=True)
-    print(f"[+] wrote {out} (keyed path, {len(payload)} bytes embedded)")
+def seed_from_passphrase(passphrase: str) -> int:
+    return int.from_bytes(hashlib.sha256(passphrase.encode()).digest(), "big")
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Keyed LSB embedding")
-    parser.add_argument("--cover", default="qrng.png")
-    parser.add_argument("--secret", default="secret.txt")
-    parser.add_argument("--output", default="stego.png")
-    parser.add_argument("--info", default="stego-path", help="HKDF info string")
-    parser.add_argument("--passphrase", help="Optional passphrase (otherwise prompted)")
-    args = parser.parse_args()
+    img = Image.open("qrng.png").convert("RGB")
+    pixels = list(img.getdata())
 
-    passphrase = (args.passphrase or getpass.getpass("Passphrase: ")).encode()
-    embed_keyed(args.cover, args.secret, args.output, info=args.info.encode(), passphrase=passphrase)
+    with open("secret.txt", "rb") as f:
+        secret = f.read()
+
+    payload = len(secret).to_bytes(4, "big") + secret
+    bits = bytes_to_bits(payload)
+
+    flat_channels = [c for px in pixels for c in px]
+    if len(bits) > len(flat_channels):
+        raise SystemExit("Secret is too large for this image.")
+
+    passphrase = getpass.getpass("Passphrase: ")
+    rng = random.Random(seed_from_passphrase(passphrase))
+    positions = list(range(len(flat_channels)))
+    rng.shuffle(positions)
+
+    for i, bit in enumerate(bits):
+        p = positions[i]
+        flat_channels[p] = (flat_channels[p] & 0xFE) | bit
+
+    out_pixels = [tuple(flat_channels[i:i+3]) for i in range(0, len(flat_channels), 3)]
+    out = Image.new("RGB", img.size)
+    out.putdata(out_pixels)
+    out.save("stego.png")
+    print("Wrote stego.png (keyed)")
 
 
 if __name__ == "__main__":

--- a/Security_Scripts/qrng_steganography/extract.py
+++ b/Security_Scripts/qrng_steganography/extract.py
@@ -1,39 +1,30 @@
 #!/usr/bin/env python3
 
-import argparse
-
-import numpy as np
 from PIL import Image
-import zlib
-
-MAGIC = b"IDST"
 
 
-def extract(stego_path: str, output: str) -> None:
-    img = Image.open(stego_path).convert("RGB")
-    arr = np.array(img)
-    bits = (arr.reshape(-1) & 1)
-    header = np.packbits(bits[:96]).tobytes()
-    if header[:4] != MAGIC:
-        raise SystemExit("[-] No payload header located")
-    length = int.from_bytes(header[4:8], "big")
-    crc_ref = int.from_bytes(header[8:12], "big")
-    total_bits = (12 + length) * 8
-    payload = np.packbits(bits[:total_bits]).tobytes()
-    secret = payload[12:12 + length]
-    crc = zlib.crc32(secret)
-    with open(output, "wb") as fh:
-        fh.write(secret)
-    status = "OK" if crc == crc_ref else "BAD"
-    print(f"[+] Recovered {len(secret)} bytes to {output} (CRC {status})")
+def bits_to_bytes(bits: list[int]) -> bytes:
+    out = bytearray()
+    for i in range(0, len(bits), 8):
+        b = 0
+        for bit in bits[i:i+8]:
+            b = (b << 1) | bit
+        out.append(b)
+    return bytes(out)
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Extract LSB-hidden payloads")
-    parser.add_argument("--stego", default="stego.png", help="Image containing hidden data")
-    parser.add_argument("--output", default="recovered.txt", help="File to write the extracted secret")
-    args = parser.parse_args()
-    extract(args.stego, args.output)
+    img = Image.open("stego.png").convert("RGB")
+    flat_channels = [c for px in img.getdata() for c in px]
+    lsb = [c & 1 for c in flat_channels]
+
+    length = int.from_bytes(bits_to_bytes(lsb[:32]), "big")
+    total_bits = 32 + length * 8
+    secret = bits_to_bytes(lsb[32:total_bits])
+
+    with open("recovered.txt", "wb") as f:
+        f.write(secret)
+    print("Wrote recovered.txt")
 
 
 if __name__ == "__main__":

--- a/Security_Scripts/qrng_steganography/extract_keyed.py
+++ b/Security_Scripts/qrng_steganography/extract_keyed.py
@@ -1,68 +1,43 @@
 #!/usr/bin/env python3
 
-import argparse
 import getpass
 import hashlib
+import random
 
-import numpy as np
 from PIL import Image
-import zlib
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-
-MAGIC = b"IDKT"
 
 
-def derive_key(passphrase: bytes, stego_path: str, info: bytes) -> bytes:
-    salt = hashlib.sha256(open(stego_path, "rb").read()).digest()
-    hkdf = HKDF(algorithm=hashes.SHA256(), length=32, salt=salt, info=info, backend=default_backend())
-    return hkdf.derive(passphrase)
+def bits_to_bytes(bits: list[int]) -> bytes:
+    out = bytearray()
+    for i in range(0, len(bits), 8):
+        b = 0
+        for bit in bits[i:i+8]:
+            b = (b << 1) | bit
+        out.append(b)
+    return bytes(out)
 
 
-def extract_keyed(stego: str, out: str, *, info: bytes, passphrase: bytes) -> None:
-    key = derive_key(passphrase, stego, info)
-    img = Image.open(stego).convert("RGB")
-    arr = np.array(img)
-    H, W, C = arr.shape
-    N = H * W * C
-    rng = np.random.default_rng(np.frombuffer(key, dtype=np.uint64))
-    perm = np.arange(N, dtype=np.int64)
-    rng.shuffle(perm)
-    flat = arr.reshape(-1)
-
-    def read_bytes(nbytes: int) -> bytes:
-        idx = read_bytes.idx
-        need = nbytes * 8
-        pos = perm[idx : idx + need]
-        read_bytes.idx += need
-        bits = (flat[pos] & 1).astype(np.uint8)
-        return np.packbits(bits).tobytes()
-
-    read_bytes.idx = 0  # type: ignore[attr-defined]
-
-    header = read_bytes(12)
-    if header[:4] != MAGIC:
-        raise SystemExit("[-] wrong key or payload missing")
-    length = int.from_bytes(header[4:8], "big")
-    crc_ref = int.from_bytes(header[8:12], "big")
-    secret = read_bytes(length)
-    crc = zlib.crc32(secret)
-    with open(out, "wb") as fh:
-        fh.write(secret)
-    print(f"[+] recovered {len(secret)} bytes (CRC {'OK' if crc==crc_ref else 'BAD'}) -> {out}")
+def seed_from_passphrase(passphrase: str) -> int:
+    return int.from_bytes(hashlib.sha256(passphrase.encode()).digest(), "big")
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Extract keyed LSB payloads")
-    parser.add_argument("--stego", default="stego.png")
-    parser.add_argument("--output", default="recovered.txt")
-    parser.add_argument("--info", default="stego-path")
-    parser.add_argument("--passphrase", help="Optional passphrase (otherwise prompted)")
-    args = parser.parse_args()
+    img = Image.open("stego.png").convert("RGB")
+    flat_channels = [c for px in img.getdata() for c in px]
 
-    passphrase = (args.passphrase or getpass.getpass("Passphrase: ")).encode()
-    extract_keyed(args.stego, args.output, info=args.info.encode(), passphrase=passphrase)
+    passphrase = getpass.getpass("Passphrase: ")
+    rng = random.Random(seed_from_passphrase(passphrase))
+    positions = list(range(len(flat_channels)))
+    rng.shuffle(positions)
+
+    lsb = [flat_channels[p] & 1 for p in positions]
+    length = int.from_bytes(bits_to_bytes(lsb[:32]), "big")
+    total_bits = 32 + length * 8
+    secret = bits_to_bytes(lsb[32:total_bits])
+
+    with open("recovered.txt", "wb") as f:
+        f.write(secret)
+    print("Wrote recovered.txt (keyed)")
 
 
 if __name__ == "__main__":

--- a/Security_Scripts/qrng_steganography/generate_sample_cover.py
+++ b/Security_Scripts/qrng_steganography/generate_sample_cover.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import random
+from PIL import Image
+
+
+def main() -> None:
+    w, h = 512, 512
+    img = Image.new("RGB", (w, h))
+    pixels = img.load()
+
+    for y in range(h):
+        for x in range(w):
+            pixels[x, y] = (
+                random.randrange(256),
+                random.randrange(256),
+                random.randrange(256),
+            )
+
+    img.save("qrng.png")
+    print("Wrote qrng.png (synthetic pseudo-random test carrier)")
+
+
+if __name__ == "__main__":
+    main()

--- a/Security_Scripts/qrng_steganography/requirements.txt
+++ b/Security_Scripts/qrng_steganography/requirements.txt
@@ -1,4 +1,2 @@
-Pillow==10.4.0
-numpy==1.26.4
-numpy==2.1.2
-cryptography==43.0.1
+Pillow
+numpy


### PR DESCRIPTION
### Motivation
- Simplify and modernize the least-significant-bit (LSB) steganography utilities by removing heavy binary dependencies and making the tools easier to run for local experiments. 
- Provide a deterministic keyed mode and a synthetic cover generator for testing when a real QRNG image is not available. 

### Description
- Rewrote `embed.py`, `embed_keyed.py`, `extract.py`, and `extract_keyed.py` to remove `numpy` and `cryptography`-based HKDF/CRC logic and implement pure-Python bit packing/unpacking via `bytes_to_bits`/`bits_to_bytes` helpers. 
- Simplified payload format to `4`-byte big-endian length header followed by the secret bytes; bits are written/read from the LSBs of RGB channels. 
- Keyed mode now derives a deterministic RNG seed from `sha256(passphrase)` (`seed_from_passphrase`) and uses `random.Random` to shuffle channel positions before embedding/extraction. 
- Added `generate_sample_cover.py` to create a pseudo-random `qrng.png` for testing, added a `.gitignore` for transient files, and updated `README.md` with usage and data format notes. 
- Trimmed `requirements.txt` to keep only `Pillow` and `numpy` and removed unused optional dependencies from the scripts. 

### Testing
- No automated test suite was added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd840c968c8322a58c298023cd279e)