### PR TITLE
Fix invalid and malformed port parsing in TCP scanner

### DIFF
--- a/Security_Scripts/port-scanner/port-scanner.py
+++ b/Security_Scripts/port-scanner/port-scanner.py
@@ -12,18 +12,30 @@ from typing import Iterable, List
 TOP_PORTS = [80, 443, 22, 21, 25, 110, 143, 3389, 8080, 8443, 5900, 445, 139, 53, 123]
 
 
+def _validate_port(port: int) -> int:
+    if not 1 <= port <= 65535:
+        raise ValueError(f"Invalid port {port}: must be in range 1-65535")
+    return port
+
+
 def parse_ports(port_spec: str) -> Iterable[int]:
     port_spec = port_spec.strip()
     if port_spec.lower() == "top100":
         return TOP_PORTS
     if "-" in port_spec:
-        start_port, end_port = map(int, port_spec.split("-"))
+        parts = [p.strip() for p in port_spec.split("-")]
+        if len(parts) != 2:
+            raise ValueError(f"Invalid port range: {port_spec}")
+        start_port, end_port = (_validate_port(int(p)) for p in parts)
         if start_port > end_port:
             start_port, end_port = end_port, start_port
         return range(start_port, end_port + 1)
     if "," in port_spec:
-        return [int(p) for p in port_spec.split(",")]
-    return [int(port_spec)]
+        ports = [_validate_port(int(p.strip())) for p in port_spec.split(",") if p.strip()]
+        if not ports:
+            raise ValueError("No ports provided")
+        return ports
+    return [_validate_port(int(port_spec))]
 
 
 def identify_service(port: int) -> str:

--- a/Security_Scripts/port-scanner/test_port_parser.py
+++ b/Security_Scripts/port-scanner/test_port_parser.py
@@ -1,0 +1,24 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).with_name("port-scanner.py")
+spec = importlib.util.spec_from_file_location("port_scanner", MODULE_PATH)
+port_scanner = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(port_scanner)
+
+
+def test_parse_ports_accepts_spaced_comma_list():
+    assert list(port_scanner.parse_ports("22, 80,443")) == [22, 80, 443]
+
+
+def test_parse_ports_rejects_invalid_port_range_value():
+    with pytest.raises(ValueError):
+        list(port_scanner.parse_ports("0-22"))
+
+
+def test_parse_ports_rejects_malformed_range():
+    with pytest.raises(ValueError):
+        list(port_scanner.parse_ports("1-2-3"))


### PR DESCRIPTION
### Motivation
- The port parser accepted invalid port numbers and malformed ranges which could cause crashes or incorrect scan behavior, so input validation is needed.
- Port parsing is security-sensitive input handling and should fail fast with clear errors for out-of-range values.
- Comma-separated lists should tolerate whitespace and reject empty entries to avoid silent misparsing.

### Description
- Add a helper ` _validate_port` to enforce ports are within `1-65535` and raise `ValueError` for invalid values.
- Change range parsing to split and validate exactly two parts and raise `ValueError` for malformed ranges like `1-2-3` before unpacking.
- Improve comma-list parsing to `strip()` entries, reject empty lists, and validate each port value.
- Add unit tests in `Security_Scripts/port-scanner/test_port_parser.py` that exercise spaced comma lists, invalid range values, and malformed ranges.

### Testing
- Ran `pytest -q Security_Scripts/port-scanner/test_port_parser.py` and the new parser tests passed (`3 passed`).
- Ran existing project tests `pytest -q blockchain-secure-logging/tests` and they also passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e577a488832288b95685badc3b5f)