### PR TITLE
Keep Security_Scripts requirements compatible with Python 3.8+

### DIFF
--- a/Security_Scripts/requirements.txt
+++ b/Security_Scripts/requirements.txt
@@ -6,6 +6,6 @@ requests==2.34.2
 shodan==1.31.0
 python-whois==0.9.6
 ipwhois==1.3.0
-numpy==2.5.0
-scikit-learn==1.9.0
+numpy==1.24.4
+scikit-learn==1.3.2
 cryptography==49.0.0


### PR DESCRIPTION
### Motivation
- Ensure the `Security_Scripts` dependency pins remain compatible with the documented `Python 3.8+` environment because `numpy==2.5.0` requires `Python >=3.12` and would cause `pip install -r requirements.txt` to fail on Python 3.8–3.11.

### Description
- Update `Security_Scripts/requirements.txt` to pin `numpy==1.24.4` and `scikit-learn==1.3.2` in place of `numpy==2.5.0` and `scikit-learn==1.9.0` to restore compatibility with Python 3.8–3.11.

### Testing
- Ran `git diff --check` (no issues) and attempted a pip dry-run with `python3 -m pip install --dry-run --ignore-installed --only-binary=:all: --python-version 3.8 --implementation cp --abi cp38 --platform manylinux2014_x86_64 -r Security_Scripts/requirements.txt`, which was blocked by the environment (package index/proxy returned `403 Forbidden`) so the dry-run could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a388619ac648322bbb9bbb1a496ddb2)