### PR TITLE
Reject reserved log field overrides in Merkle canonicalization

### DIFF
--- a/blockchain-secure-logging/offchain/merkle.py
+++ b/blockchain-secure-logging/offchain/merkle.py
@@ -19,6 +19,10 @@ def canonical_leaf(entry: LogEntry) -> bytes:
         "msg": entry.msg,
     }
     if entry.fields:
+        reserved_keys = payload.keys() & entry.fields.keys()
+        if reserved_keys:
+            reserved = ", ".join(sorted(reserved_keys))
+            raise ValueError(f"Log entry fields cannot override reserved keys: {reserved}")
         payload.update(entry.fields)
 
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")

--- a/blockchain-secure-logging/tests/test_merkle_pipeline.py
+++ b/blockchain-secure-logging/tests/test_merkle_pipeline.py
@@ -10,6 +10,8 @@ import pathlib
 
 import sys
 
+import pytest
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -35,6 +37,20 @@ def test_log_entry_parsing_merges_dynamic_fields() -> None:
     entries = _load_entries()
     assert entries[0].fields["details"] == {"pid": 1234}
     assert entries[1].fields["user"] == "alice"
+
+
+def test_canonical_leaf_rejects_reserved_field_overrides() -> None:
+    entries = _load_entries()
+    malicious = LogEntry(
+        ts=entries[0].ts,
+        source_id=entries[0].source_id,
+        level=entries[0].level,
+        msg=entries[0].msg,
+        fields={"msg": "forged message"},
+    )
+
+    with pytest.raises(ValueError, match="reserved keys: msg"):
+        merkle.canonical_leaf(malicious)
 
 
 def test_merkle_root_matches_known_value() -> None:


### PR DESCRIPTION
### Motivation
- Prevent dynamic `fields` in log entries from overwriting reserved keys (`ts`, `source_id`, `level`, `msg`) which could change canonical serialization and enable tampering or inconsistent Merkle roots. 

### Description
- Added a reserved-key collision check in `canonical_leaf` that computes `reserved_keys = payload.keys() & entry.fields.keys()` and raises `ValueError` if any collisions are found. 
- This ensures callers cannot inject or override canonical fields prior to JSON canonicalization and hashing. 
- Added a regression test `test_canonical_leaf_rejects_reserved_field_overrides` in `blockchain-secure-logging/tests/test_merkle_pipeline.py` to assert the new behavior. 
- Modified files: `blockchain-secure-logging/offchain/merkle.py` and `blockchain-secure-logging/tests/test_merkle_pipeline.py`. 

### Testing
- Ran the unit test suite with `python -m pytest -q` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3886cdd57083228c81694ce5608cc6)