### PR TITLE
Fix Merkle manifest proof generation

### DIFF
--- a/blockchain-secure-logging/offchain/batcher.py
+++ b/blockchain-secure-logging/offchain/batcher.py
@@ -77,10 +77,18 @@ def build_manifest(batch_id: str, entries: Sequence[LogEntry], prev_root: str | 
         root="0x" + root.hex(),
     )
 
+    proofs = {
+        str(index): [
+            {"direction": direction, "hash": "0x" + sibling.hex()}
+            for direction, sibling in merkle.merkle_proof(index, leaves)
+        ]
+        for index in range(len(leaves))
+    }
+
     manifest = {
         "batch": json.loads(batch_meta.json()),
-        "leaves": [leaf.hex() for leaf in leaves],
-        "proofs": {},
+        "leaves": ["0x" + leaf.hex() for leaf in leaves],
+        "proofs": proofs,
     }
     return manifest
 

--- a/blockchain-secure-logging/tests/test_merkle_pipeline.py
+++ b/blockchain-secure-logging/tests/test_merkle_pipeline.py
@@ -87,4 +87,20 @@ def test_manifest_build_is_deterministic(tmp_path: pathlib.Path) -> None:
     assert manifest["batch"]["count"] == len(entries)
     assert manifest["batch"]["root"] == EXPECTED_ROOT
     assert manifest["batch"]["prev_merkle_root"] == EXPECTED_ROOT
+    assert len(manifest["leaves"]) == len(entries)
+    assert all(leaf.startswith("0x") for leaf in manifest["leaves"])
+    assert set(manifest["proofs"]) == {str(index) for index in range(len(entries))}
+
+
+def test_manifest_includes_verifiable_proofs_for_each_leaf() -> None:
+    entries = _load_entries()
+    manifest = build_manifest("2025-09-23T18:05Z_authsvc_demo", entries, EXPECTED_ROOT)
+    expected_root = bytes.fromhex(manifest["batch"]["root"][2:])
+
+    for index, leaf_hex in enumerate(manifest["leaves"]):
+        proof = [
+            (item["direction"], bytes.fromhex(item["hash"][2:]))
+            for item in manifest["proofs"][str(index)]
+        ]
+        assert merkle.verify_proof(bytes.fromhex(leaf_hex[2:]), proof, expected_root)
 


### PR DESCRIPTION
### Motivation
- Manifests were being emitted without per-leaf Merkle proofs and leaf hashes lacked the `0x` prefix, making manifests less useful for verification and inconsistent with other hex fields.
- Tests did not exercise proof serialization or verification, leaving a gap in regression coverage.

### Description
- Update `offchain/batcher.py` to compute a `proofs` dictionary mapping each leaf index to a serialized Merkle proof with `direction` and `hash` fields.
- Standardize serialized leaf hashes in the manifest to include the `0x` prefix to match the `root` field.
- Add assertions and a new test in `blockchain-secure-logging/tests/test_merkle_pipeline.py` to ensure manifests contain all expected `leaves` and `proofs` and that each serialized proof verifies against the stored root.
- Keep manifest structure: `batch`, `leaves`, and `proofs` where `proofs` keys are stringified indices and proof entries are dicts with `direction` and `hash`.

### Testing
- Ran `python -m pytest -q`, which succeeded with `9 passed`.
- Verified repository formatting checks with `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3887dfe15c83229bf5d4278dad12f5)