### PR TITLE
Cache Merkle proofs during manifest generation

### DIFF
--- a/blockchain-secure-logging/offchain/batcher.py
+++ b/blockchain-secure-logging/offchain/batcher.py
@@ -77,12 +77,13 @@ def build_manifest(batch_id: str, entries: Sequence[LogEntry], prev_root: str | 
         root="0x" + root.hex(),
     )
 
+    all_proofs = merkle.merkle_proofs(leaves)
     proofs = {
         str(index): [
             {"direction": direction, "hash": "0x" + sibling.hex()}
-            for direction, sibling in merkle.merkle_proof(index, leaves)
+            for direction, sibling in proof
         ]
-        for index in range(len(leaves))
+        for index, proof in enumerate(all_proofs)
     }
 
     manifest = {

--- a/blockchain-secure-logging/offchain/merkle.py
+++ b/blockchain-secure-logging/offchain/merkle.py
@@ -41,47 +41,71 @@ def _pairwise(iterable: Sequence[bytes]) -> Iterable[Tuple[bytes, bytes]]:
         yield left, right
 
 
-def merkle_root(leaves: Sequence[bytes]) -> bytes:
-    """Return the Merkle root for the given list of leaf hashes."""
+def merkle_tree_levels(leaves: Sequence[bytes]) -> List[List[bytes]]:
+    """Build and return every level in a Merkle tree.
+
+    The returned list starts with the original leaf level and ends with the
+    single root hash level. Odd-width levels are duplicated before parent
+    hashes are calculated so sibling lookups can reuse the cached structure.
+    """
 
     if not leaves:
-        raise ValueError("Cannot compute Merkle root with no leaves")
+        raise ValueError("Cannot build Merkle tree with no leaves")
 
-    level: List[bytes] = list(leaves)
-    while len(level) > 1:
+    levels: List[List[bytes]] = [list(leaves)]
+    while len(levels[-1]) > 1:
+        level = list(levels[-1])
+        if len(level) % 2 == 1:
+            level.append(level[-1])
+
         next_level: List[bytes] = []
         for left, right in _pairwise(level):
             next_level.append(hashlib.sha256(left + right).digest())
-        level = next_level
-    return level[0]
+        levels.append(next_level)
+
+    return levels
+
+def merkle_root(leaves: Sequence[bytes]) -> bytes:
+    """Return the Merkle root for the given list of leaf hashes."""
+
+    try:
+        return merkle_tree_levels(leaves)[-1][0]
+    except ValueError as exc:
+        raise ValueError("Cannot compute Merkle root with no leaves") from exc
 
 
-def merkle_proof(target_index: int, leaves: Sequence[bytes]) -> List[Tuple[str, bytes]]:
-    """Generate a Merkle proof for the leaf at ``target_index``."""
+def merkle_proof_from_levels(target_index: int, levels: Sequence[Sequence[bytes]]) -> List[Tuple[str, bytes]]:
+    """Generate a Merkle proof for ``target_index`` from cached tree levels."""
 
-    if not 0 <= target_index < len(leaves):
+    if not levels or not 0 <= target_index < len(levels[0]):
         raise IndexError("target_index out of bounds")
 
     proof: List[Tuple[str, bytes]] = []
     idx = target_index
-    level = list(leaves)
-
-    while len(level) > 1:
+    for raw_level in levels[:-1]:
+        level = list(raw_level)
         if len(level) % 2 == 1:
             level.append(level[-1])
 
         sibling_idx = idx ^ 1
         direction = "left" if sibling_idx < idx else "right"
         proof.append((direction, level[sibling_idx]))
-
-        next_level: List[bytes] = []
-        for left, right in _pairwise(level):
-            next_level.append(hashlib.sha256(left + right).digest())
-
-        level = next_level
         idx //= 2
 
     return proof
+
+
+def merkle_proof(target_index: int, leaves: Sequence[bytes]) -> List[Tuple[str, bytes]]:
+    """Generate a Merkle proof for the leaf at ``target_index``."""
+
+    return merkle_proof_from_levels(target_index, merkle_tree_levels(leaves))
+
+
+def merkle_proofs(leaves: Sequence[bytes]) -> List[List[Tuple[str, bytes]]]:
+    """Generate proofs for all leaves while building tree levels only once."""
+
+    levels = merkle_tree_levels(leaves)
+    return [merkle_proof_from_levels(index, levels) for index in range(len(leaves))]
 
 
 def verify_proof(leaf: bytes, proof: Sequence[Tuple[str, bytes]], expected_root: bytes) -> bool:
@@ -102,6 +126,9 @@ __all__ = [
     "canonical_leaf",
     "leaf_hash",
     "merkle_root",
+    "merkle_tree_levels",
+    "merkle_proof_from_levels",
     "merkle_proof",
+    "merkle_proofs",
     "verify_proof",
 ]

--- a/blockchain-secure-logging/tests/test_merkle_pipeline.py
+++ b/blockchain-secure-logging/tests/test_merkle_pipeline.py
@@ -79,6 +79,27 @@ def test_merkle_proof_detects_tampering() -> None:
     assert not merkle.verify_proof(tampered_leaf, proof, root)
 
 
+def test_cached_merkle_proofs_match_single_proof_generation() -> None:
+    entries = _load_entries()
+    leaves = [merkle.leaf_hash(entry) for entry in entries]
+
+    cached_proofs = merkle.merkle_proofs(leaves)
+
+    assert cached_proofs == [merkle.merkle_proof(index, leaves) for index in range(len(leaves))]
+
+
+def test_manifest_build_uses_cached_proof_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    entries = _load_entries()
+
+    def fail_single_proof_generation(index: int, leaves: list[bytes]) -> list[tuple[str, bytes]]:
+        raise AssertionError("build_manifest should serialize cached proofs instead")
+
+    monkeypatch.setattr(merkle, "merkle_proof", fail_single_proof_generation)
+    manifest = build_manifest("2025-09-23T18:05Z_authsvc_demo", entries, EXPECTED_ROOT)
+
+    assert set(manifest["proofs"]) == {str(index) for index in range(len(entries))}
+
+
 def test_manifest_build_is_deterministic(tmp_path: pathlib.Path) -> None:
     entries = _load_entries()
     manifest = build_manifest("2025-09-23T18:05Z_authsvc_demo", entries, EXPECTED_ROOT)


### PR DESCRIPTION
### Motivation
- Computing a Merkle proof previously rebuilt tree levels for each leaf, which makes manifest generation quadratic in batch size and stalls large-batch anchoring.
- Tree levels can be computed once and reused to serialize all proofs efficiently.

### Description
- Add `merkle_tree_levels(leaves: Sequence[bytes]) -> List[List[bytes]]` to build and return every Merkle tree level so callers can reuse computed levels.
- Add `merkle_proof_from_levels(target_index: int, levels: Sequence[Sequence[bytes]])` and `merkle_proofs(leaves: Sequence[bytes])` to derive single and all proofs from cached levels.
- Keep API compatibility by making `merkle_proof` delegate to `merkle_proof_from_levels` and make `merkle_root` use `merkle_tree_levels`.
- Update `build_manifest` to call `merkle.merkle_proofs(leaves)` once and serialize the returned proofs instead of calling `merkle.merkle_proof` per leaf.
- Export the new helpers in `__all__` and add regression tests `test_cached_merkle_proofs_match_single_proof_generation` and `test_manifest_build_uses_cached_proof_generation` to assert parity and that `build_manifest` uses the cached path.

### Testing
- Ran `python -m pytest blockchain-secure-logging/tests/test_merkle_pipeline.py` and all tests passed (`8 passed`).
- Ran automated diff checks (`git diff --check`) with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3889be33248322a29b1c5e6b2419f1)