### PR TITLE
Fix batcher direct script execution

### DIFF
--- a/blockchain-secure-logging/offchain/batcher.py
+++ b/blockchain-secure-logging/offchain/batcher.py
@@ -28,6 +28,10 @@ try:
 except ImportError:  # pragma: no cover - dependency only needed for CLI usage
     yaml = None
 
+if __package__ in {None, ""}:  # pragma: no cover - exercised via subprocess CLI test
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+    __package__ = "offchain"
+
 from . import merkle
 from .schemas import BatchMeta, LogEntry
 

--- a/blockchain-secure-logging/tests/test_batcher_cli.py
+++ b/blockchain-secure-logging/tests/test_batcher_cli.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_batcher_script_help_runs_when_executed_by_path():
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "blockchain-secure-logging" / "offchain" / "batcher.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--config" in result.stdout
+    assert "--batch-id" in result.stdout


### PR DESCRIPTION
### Motivation
- The `offchain/batcher.py` module documents execution by file path but failed with `ImportError: attempted relative import with no known parent package` when run directly. 
- Ensure the CLI can be executed as a script in CI and user workflows without requiring package installation.

### Description
- Add a small startup guard that inserts the package parent directory on `sys.path` and sets `__package__` when `__package__` is `None` or empty to allow the existing relative imports to work when run as a script by path (`offchain/batcher.py`).
- Add a regression test `blockchain-secure-logging/tests/test_batcher_cli.py` that runs the script as a subprocess and verifies the CLI help prints `--config` and `--batch-id`.
- Changes are contained in `blockchain-secure-logging/offchain/batcher.py` and the new test file under `blockchain-secure-logging/tests`.

### Testing
- Ran `python -m pytest -q` and all tests passed (`12 passed`).
- Executed `python blockchain-secure-logging/offchain/batcher.py --help` and observed a successful exit and help output containing `--config` and `--batch-id`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a388c60a5e483228ea4410cabda7011)