### PR TITLE
Fix batcher config-relative source paths

### DIFF
--- a/blockchain-secure-logging/offchain/batcher.py
+++ b/blockchain-secure-logging/offchain/batcher.py
@@ -47,8 +47,12 @@ class BatchInputs:
 def load_config(path: pathlib.Path) -> dict:
     if yaml is None:
         raise RuntimeError("PyYAML is required to load configuration files")
-    with path.open("r", encoding="utf-8") as handle:
-        return yaml.safe_load(handle)
+
+    resolved_path = path.resolve()
+    with resolved_path.open("r", encoding="utf-8") as handle:
+        config = yaml.safe_load(handle) or {}
+    config["_base_dir"] = str(resolved_path.parent)
+    return config
 
 
 def read_jsonl(path: pathlib.Path) -> Iterable[LogEntry]:
@@ -59,10 +63,18 @@ def read_jsonl(path: pathlib.Path) -> Iterable[LogEntry]:
             yield LogEntry.parse_raw(line)
 
 
+def _resolve_config_path(path_value: str, base_dir: pathlib.Path | None) -> pathlib.Path:
+    path = pathlib.Path(path_value).expanduser()
+    if path.is_absolute() or base_dir is None:
+        return path
+    return (base_dir / path).resolve()
+
+
 def gather_entries(config: dict) -> BatchInputs:
     entries: List[LogEntry] = []
+    base_dir = pathlib.Path(config["_base_dir"]) if config.get("_base_dir") else None
     for source in config.get("sources", []):
-        source_path = pathlib.Path(source["path"])
+        source_path = _resolve_config_path(source["path"], base_dir)
         entries.extend(read_jsonl(source_path))
     prev_root = config.get("state", {}).get("prev_merkle_root")
     entries.sort(key=lambda e: e.ts)

--- a/blockchain-secure-logging/tests/test_batcher_cli.py
+++ b/blockchain-secure-logging/tests/test_batcher_cli.py
@@ -18,3 +18,29 @@ def test_batcher_script_help_runs_when_executed_by_path():
     assert result.returncode == 0, result.stderr
     assert "--config" in result.stdout
     assert "--batch-id" in result.stdout
+
+
+def test_batcher_script_resolves_sources_relative_to_config(tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    project_root = repo_root / "blockchain-secure-logging"
+    script = project_root / "offchain" / "batcher.py"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--config",
+            "offchain/config.yaml",
+            "--batch-id",
+            "demo",
+            "--manifest-dir",
+            str(tmp_path),
+        ],
+        cwd=project_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "demo.manifest.json").exists()


### PR DESCRIPTION
### Motivation
- The batcher failed when invoked from a different working directory because configured source paths were interpreted relative to the process CWD instead of the configuration file location.

### Description
- `load_config()` now resolves the config file path, safely handles empty YAML, and records the config directory in `config["_base_dir"]`.
- Added `_resolve_config_path()` to expand user paths and resolve relative sources against the config directory while preserving absolute-path behavior.
- Updated `gather_entries()` to resolve each source path via `_resolve_config_path()` and then read the JSONL fixtures.
- Added a CLI regression test `test_batcher_script_resolves_sources_relative_to_config` which invokes the documented `--config offchain/config.yaml` pattern from the project root and asserts the manifest is created.

### Testing
- Executed the batcher CLI: `python offchain/batcher.py --config offchain/config.yaml --batch-id demo --manifest-dir /tmp/manifests-fixed`, which wrote the manifest successfully.
- Ran the automated test suite with `pytest -q` in multiple invocations; tests completed successfully (observed runs: `9 passed`, then `13 passed` after adding tests, and a final module run showing `10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a388efba5288322b0814b1dc33cd550)