### PR TITLE
Handle malformed bytes32 API input

### DIFF
--- a/blockchain-secure-logging/offchain/api.py
+++ b/blockchain-secure-logging/offchain/api.py
@@ -148,7 +148,10 @@ def _bytes32(value: Optional[str]) -> bytes:
     stripped = value[2:] if value.startswith("0x") else value
     if len(stripped) != 64:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Expected 32-byte hex value, got {value}")
-    return bytes.fromhex(stripped)
+    try:
+        return bytes.fromhex(stripped)
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Expected 32-byte hex value, got {value}") from exc
 
 
 def _resolve_manifest_dir(config: Dict[str, Any], override: Optional[str]) -> pathlib.Path:

--- a/blockchain-secure-logging/tests/test_api_helpers.py
+++ b/blockchain-secure-logging/tests/test_api_helpers.py
@@ -1,0 +1,23 @@
+"""Regression tests for API helper validation."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+from fastapi import HTTPException, status
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from offchain.api import _bytes32
+
+
+def test_bytes32_rejects_non_hex_input_with_http_400() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        _bytes32("0x" + "z" * 64)
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Expected 32-byte hex value" in exc_info.value.detail


### PR DESCRIPTION
### Motivation

- Ensure the API helper `_bytes32` returns a FastAPI `HTTPException` with status 400 for malformed non-hex 32-byte inputs instead of letting `bytes.fromhex` raise an unhandled `ValueError`.

### Description

- Add a try/except around `bytes.fromhex` in `_bytes32` to convert `ValueError` into `HTTPException(status.HTTP_400_BAD_REQUEST)` in `blockchain-secure-logging/offchain/api.py`.
- Add a regression test `blockchain-secure-logging/tests/test_api_helpers.py` that asserts non-hex input yields an HTTP 400 response.

### Testing

- Ran the full test suite with `pytest -q` and all tests passed (`14 passed, 1 warning`).
- The new regression test `tests/test_api_helpers.py` exercised the invalid-hex case and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a389568ebec8322a387ef793d914370)